### PR TITLE
Refactor UI into new Screen subclasses

### DIFF
--- a/src/Tomatotent.ino
+++ b/src/Tomatotent.ino
@@ -199,47 +199,6 @@ void touchHandler(void)
     p.x += 20; // calibration
 
     screenManager.current->processTouch(p.x, p.y);
-
-    return;
-
-    //WAS A BUTTON TOUCHED - And which one?
-    uint8_t c { 0 };
-
-    for (c = 0; c < (sizeof(screenManager.buttons) / sizeof(screenManager.buttons[0])); ++c) {
-        Button& btn = screenManager.buttons[c];
-        if (!btn.isPressed(p.x, p.y)) {
-            continue;
-        }
-        if (btn.getStatus() != "none") {
-            continue;
-        }
-
-        btn.setStatus("pressed");
-
-        if (btn.getName() == "startGrowBtn") {
-            tent.growLight("HIGH");
-            systemStatus.setDayCount(1);
-
-            screenManager.growStartedScreen();
-
-            delay(3000);
-
-            screenManager.homeScreen();
-
-            tent.doCheckStats(); //First time right away
-            draw_temp_home.start();
-
-            systemStatus.countMinute(); // First time on new grow
-            minutelyTicker.start();
-
-            break;
-        }
-
-        if (btn.getName() == "wifiBtn") {
-            screenManager.wifiScreen();
-            break;
-        }
-    }
 }
 
 void loop(void)

--- a/src/Tomatotent.ino
+++ b/src/Tomatotent.ino
@@ -235,24 +235,6 @@ void touchHandler(void)
             break;
         }
 
-        //CANCEL SCREEN
-
-        if (btn.getName() == "terminateYesBtn") {
-            tent.growLight("OFF");
-            draw_temp_home.stop();
-            tent.fan("OFF");
-            minutelyTicker.stop();
-
-            systemStatus.init();
-            screenManager.homeScreen();
-            break;
-        }
-
-        if (btn.getName() == "terminateNoBtn") {
-            screenManager.homeScreen();
-            break;
-        }
-
         //TIMER SCREEN
         if (btn.getName() == "timerUpBtn") {
             int dayDuration = systemStatus.getDayDuration() + 60;

--- a/src/Tomatotent.ino
+++ b/src/Tomatotent.ino
@@ -154,7 +154,8 @@ void setup()
 
     //END REMOTE FUNCTIONS
 
-    screenManager.homeScreen();
+    //screenManager.homeScreen();
+    screenManager.current->render();
 
     tent.begin();
 
@@ -194,6 +195,10 @@ void touchHandler(void)
 
     TS_Point p = ts.getPosition();
     p.x += 20; // calibration
+
+    screenManager.current->processTouch(p.x, p.y);
+
+    return;
 
     //WAS A BUTTON TOUCHED - And which one?
     uint8_t c { 0 };

--- a/src/Tomatotent.ino
+++ b/src/Tomatotent.ino
@@ -235,56 +235,6 @@ void touchHandler(void)
             break;
         }
 
-        //TIMER SCREEN
-        if (btn.getName() == "timerUpBtn") {
-            int dayDuration = systemStatus.getDayDuration() + 60;
-
-            if (dayDuration > 1440) {
-                dayDuration = 60;
-            }
-
-            systemStatus.setDayDuration(dayDuration);
-
-            tft.fillRect(10, 70, 200, 22, ILI9341_BLACK);
-            tft.setTextColor(ILI9341_WHITE);
-            tft.setTextSize(2);
-            tft.setCursor(10, 70);
-            tft.print(String(dayDuration / 60) + " Hours ON");
-
-            tft.setCursor(10, 140);
-            tft.fillRect(10, 140, 215, 22, ILI9341_BLACK);
-            int nightDuration = (24 * 60) - dayDuration;
-            tft.print(String(nightDuration / 60) + " Hours OFF");
-
-            break;
-        }
-        if (btn.getName() == "timerDownBtn") {
-            int dayDuration = systemStatus.getDayDuration() - 60;
-
-            if (dayDuration <= 0) {
-                dayDuration = 1440;
-            }
-
-            systemStatus.setDayDuration(dayDuration);
-
-            tft.fillRect(10, 70, 200, 22, ILI9341_BLACK);
-            tft.setTextColor(ILI9341_WHITE);
-            tft.setTextSize(2);
-            tft.setCursor(10, 70);
-            tft.print(String(dayDuration / 60) + " Hours ON");
-
-            tft.setCursor(10, 140);
-            tft.fillRect(10, 140, 215, 22, ILI9341_BLACK);
-            int nightDuration = (24 * 60) - dayDuration;
-            tft.print(String(nightDuration / 60) + " Hours OFF");
-            break;
-        }
-
-        if (btn.getName() == "timerOkBtn") {
-            screenManager.homeScreen();
-            break;
-        }
-
         if (btn.getName() == "wifiBtn") {
             screenManager.wifiScreen();
             break;

--- a/src/Tomatotent.ino
+++ b/src/Tomatotent.ino
@@ -90,7 +90,7 @@ void myPage(const char* url, ResponseCallback* cb, void* cbArg, Reader* body, Wr
 
 void setup_handler()
 {
-    screenManager.wifiSetupScreen();
+    screenManager.wifiSplashScreen();
     tent.tp->stop();
     tent.tp1->stop();
 }

--- a/src/Tomatotent.ino
+++ b/src/Tomatotent.ino
@@ -239,24 +239,6 @@ void touchHandler(void)
             screenManager.wifiScreen();
             break;
         }
-
-        if (btn.getName() == "wifiOnBtn") {
-            Particle.connect();
-            screenManager.homeScreen();
-            break;
-        }
-
-        if (btn.getName() == "wifiOffBtn") {
-            Particle.disconnect();
-            WiFi.off();
-            screenManager.homeScreen();
-            break;
-        }
-
-        if (btn.getName() == "wifiOkBtn") {
-            screenManager.homeScreen();
-            break;
-        }
     }
 }
 

--- a/src/Tomatotent.ino
+++ b/src/Tomatotent.ino
@@ -137,6 +137,9 @@ void setup()
     pinMode(GROW_LIGHT_ON_OFF_PIN, OUTPUT);
     pinMode(DIM_PIN, INPUT_PULLUP);
 
+    tft.fillScreen(ILI9341_BLACK);
+    analogWrite(TFT_BRIGHTNESS_PIN, 255);
+
     //TOUCH
     ts.begin();
     ts.setRotation(3); // 1 for 2.4 screen, 3 for 2.8

--- a/src/Tomatotent.ino
+++ b/src/Tomatotent.ino
@@ -198,7 +198,9 @@ void touchHandler(void)
     TS_Point p = ts.getPosition();
     p.x += 20; // calibration
 
-    screenManager.current->processTouch(p.x, p.y);
+    if (screenManager.current) {
+        screenManager.current->processTouch(p.x, p.y);
+    }
 }
 
 void loop(void)

--- a/src/Tomatotent.ino
+++ b/src/Tomatotent.ino
@@ -237,16 +237,6 @@ void touchHandler(void)
 
         //CANCEL SCREEN
 
-        if (btn.getName() == "cancelScreenOkBtn") {
-            screenManager.homeScreen();
-            break;
-        }
-
-        if (btn.getName() == "terminateBtn") {
-            screenManager.cancelConfirmationScreen();
-            break;
-        }
-
         if (btn.getName() == "terminateYesBtn") {
             tent.growLight("OFF");
             draw_temp_home.stop();

--- a/src/Tomatotent.ino
+++ b/src/Tomatotent.ino
@@ -258,61 +258,6 @@ void touchHandler(void)
             break;
         }
 
-        if (btn.getName() == "fanAutoBtn") {
-            systemStatus.setFanAutoMode(1);
-            screenManager.renderButtons(true);
-            systemStatus.check_fan();
-            break;
-        }
-
-        if (btn.getName() == "fanManualBtn") {
-            systemStatus.setFanAutoMode(0);
-            screenManager.renderButtons(true);
-            systemStatus.check_fan();
-            break;
-        }
-
-        if (btn.getName() == "fanUpBtn") {
-            float fanSpeedPercent = systemStatus.getFanSpeed();
-
-            //set to manual
-            systemStatus.setFanAutoMode(0);
-
-            screenManager.renderButtons(true);
-
-            if (fanSpeedPercent < 100) {
-
-                fanSpeedPercent += 5;
-
-                systemStatus.setFanSpeed(fanSpeedPercent);
-                systemStatus.check_fan();
-            }
-            break;
-        }
-
-        if (btn.getName() == "fanDownBtn") {
-            float fanSpeedPercent = systemStatus.getFanSpeed();
-
-            //set to manual
-            systemStatus.setFanAutoMode(0);
-
-            screenManager.renderButtons(true);
-
-            if (fanSpeedPercent > 0) {
-
-                fanSpeedPercent -= 5;
-
-                systemStatus.setFanSpeed(fanSpeedPercent);
-                systemStatus.check_fan();
-            }
-            break;
-        }
-
-        if (btn.getName() == "fanOkBtn") {
-            screenManager.homeScreen();
-            break;
-        }
-
         //temp unit select screen
         if (btn.getName() == "tempCelsiusBtn") {
             systemStatus.setTempUnit('C');

--- a/src/Tomatotent.ino
+++ b/src/Tomatotent.ino
@@ -154,8 +154,7 @@ void setup()
 
     //END REMOTE FUNCTIONS
 
-    //screenManager.homeScreen();
-    screenManager.current->render();
+    screenManager.homeScreen();
 
     tent.begin();
 
@@ -230,21 +229,6 @@ void touchHandler(void)
             systemStatus.countMinute(); // First time on new grow
             minutelyTicker.start();
 
-            break;
-        }
-
-        if (btn.getName() == "timerBtn") {
-            screenManager.timerScreen();
-            break;
-        }
-
-        if (btn.getName() == "dayCounterBtn") {
-            screenManager.cancelScreen();
-            break;
-        }
-
-        if (btn.getName() == "tempBtn") {
-            screenManager.tempUnitScreen();
             break;
         }
 
@@ -346,11 +330,6 @@ void touchHandler(void)
 
         if (btn.getName() == "wifiOkBtn") {
             screenManager.homeScreen();
-            break;
-        }
-
-        if (btn.getName() == "fanBtn") {
-            screenManager.fanScreen();
             break;
         }
 

--- a/src/Tomatotent.ino
+++ b/src/Tomatotent.ino
@@ -257,23 +257,6 @@ void touchHandler(void)
             screenManager.homeScreen();
             break;
         }
-
-        //temp unit select screen
-        if (btn.getName() == "tempCelsiusBtn") {
-            systemStatus.setTempUnit('C');
-            screenManager.renderButtons(true);
-            screenManager.homeScreen();
-            tent.check_temperature(systemStatus.getTempUnit());
-            break;
-        }
-
-        if (btn.getName() == "tempFahrenheitBtn") {
-            systemStatus.setTempUnit('F');
-            screenManager.renderButtons(true);
-            screenManager.homeScreen();
-            tent.check_temperature(systemStatus.getTempUnit());
-            break;
-        }
     }
 }
 

--- a/src/button.cpp
+++ b/src/button.cpp
@@ -52,53 +52,6 @@ void Button::render()
         tft.print(buttonText);
     }
 
-    if (this->getName() == "fanAutoBtn") {
-        tft.drawRect(x0, y0, w, h, ILI9341_WHITE);
-
-        if (systemStatus.getFanAutoMode()) {
-            tft.fillRect(x0 + 1, y0 + 1, w - 2, h - 2, ILI9341_OLIVE);
-        } else {
-            tft.fillRect(x0 + 1, y0 + 1, w - 2, h - 2, ILI9341_BLACK);
-        }
-        tft.setCursor(x0 + textOffsetLeft, y0 + textOffsetTop);
-        tft.setTextColor(ILI9341_WHITE);
-        tft.setTextSize(2);
-        tft.print(buttonText);
-    }
-
-    if (this->getName() == "fanManualBtn") {
-        tft.drawRect(x0, y0, w, h, ILI9341_WHITE);
-
-        if (!systemStatus.getFanAutoMode()) {
-            tft.fillRect(x0 + 1, y0 + 1, w - 2, h - 2, ILI9341_OLIVE);
-        } else {
-            tft.fillRect(x0 + 1, y0 + 1, w - 2, h - 2, ILI9341_BLACK);
-        }
-        tft.setCursor(x0 + textOffsetLeft, y0 + textOffsetTop);
-        tft.setTextColor(ILI9341_WHITE);
-        tft.setTextSize(2);
-        tft.print(buttonText);
-    }
-
-    if (this->getName() == "fanUpBtn") {
-        tft.fillTriangle(240, 95, 260, 55, 280, 95, ILI9341_RED);
-        tft.drawTriangle(240, 95, 260, 55, 280, 95, ILI9341_LIGHTGREY);
-    }
-
-    if (this->getName() == "fanDownBtn") {
-        tft.fillTriangle(240, 110, 260, 150, 280, 110, ILI9341_RED);
-        tft.drawTriangle(240, 110, 260, 150, 280, 110, ILI9341_LIGHTGREY);
-    }
-
-    if (this->getName() == "fanOkBtn") {
-        tft.drawRect(x0, y0, w, h, ILI9341_WHITE);
-        tft.fillRect(x0 + 1, y0 + 1, w - 2, h - 2, ILI9341_OLIVE);
-        tft.setCursor(x0 + textOffsetLeft, y0 + textOffsetTop);
-        tft.setTextColor(ILI9341_WHITE);
-        tft.setTextSize(3);
-        tft.print(buttonText);
-    }
-
     if (this->getName() == "tempFahrenheitBtn") {
         tft.drawRect(x0, y0, w, h, ILI9341_WHITE);
 
@@ -145,14 +98,6 @@ void Button::renderPressed()
     }
     if (this->getName() == "timerDownBtn") {
         tft.fillTriangle(240, 170, 260, 130, 280, 170, ILI9341_WHITE);
-    }
-
-    if (this->getName() == "fanUpBtn") {
-        tft.fillTriangle(240, 95, 260, 55, 280, 95, ILI9341_WHITE);
-    }
-
-    if (this->getName() == "fanDownBtn") {
-        tft.fillTriangle(240, 110, 260, 150, 280, 110, ILI9341_WHITE);
     }
 }
 

--- a/src/button.cpp
+++ b/src/button.cpp
@@ -92,13 +92,6 @@ void Button::render()
 
 void Button::renderPressed()
 {
-
-    if (this->getName() == "timerUpBtn") {
-        tft.fillTriangle(240, 95, 260, 55, 280, 95, ILI9341_WHITE);
-    }
-    if (this->getName() == "timerDownBtn") {
-        tft.fillTriangle(240, 170, 260, 130, 280, 170, ILI9341_WHITE);
-    }
 }
 
 bool Button::isPressed(int x, int y)

--- a/src/button.cpp
+++ b/src/button.cpp
@@ -25,20 +25,6 @@ Button::Button(String name, uint16_t x0, uint16_t y0, uint16_t w, uint16_t h, St
 
 void Button::render()
 {
-    if (this->getName() == "startGrowBtn") {
-        tft.drawRect(x0, y0, w, h, ILI9341_WHITE);
-
-        tft.fillRect(x0 + 1, y0 + 1, w - 2, h - 2, ILI9341_OLIVE);
-
-        tft.setCursor(x0 + textOffsetLeft, y0 + textOffsetTop);
-        tft.setTextColor(ILI9341_WHITE);
-        tft.setTextSize(3);
-
-        tft.print(buttonText);
-    }
-
-    if (this->getName() == "dayCounterBtn") {
-    }
 
     if (this->getName() == "cancelScreenOkBtn") {
         tft.drawRect(x0, y0, w, h, ILI9341_WHITE);
@@ -88,9 +74,6 @@ void Button::render()
         tft.print(buttonText);
     }
 
-    if (this->getName() == "timerBtn") {
-    }
-
     if (this->getName() == "timerUpBtn") {
         tft.fillTriangle(240, 95, 260, 55, 280, 95, ILI9341_RED);
         tft.drawTriangle(240, 95, 260, 55, 280, 95, ILI9341_LIGHTGREY);
@@ -108,10 +91,6 @@ void Button::render()
         tft.setTextColor(ILI9341_WHITE);
         tft.setTextSize(3);
         tft.print(buttonText);
-    }
-
-    if (this->getName() == "wifiBtn") {
-        tft.drawBitmap(289, 5, iconWifi_24x24, 24, 24, ILI9341_DARKGREY);
     }
 
     if (this->getName() == "wifiOnBtn") {
@@ -139,9 +118,6 @@ void Button::render()
         tft.setTextColor(ILI9341_WHITE);
         tft.setTextSize(3);
         tft.print(buttonText);
-    }
-
-    if (this->getName() == "fanBtn") {
     }
 
     if (this->getName() == "fanAutoBtn") {
@@ -191,9 +167,6 @@ void Button::render()
         tft.print(buttonText);
     }
 
-    if (this->getName() == "tempBtn") {
-    }
-
     if (this->getName() == "tempFahrenheitBtn") {
         tft.drawRect(x0, y0, w, h, ILI9341_WHITE);
 
@@ -234,9 +207,6 @@ void Button::render()
 
 void Button::renderPressed()
 {
-    if (this->getName() == "startGrowBtn") {
-        tft.drawRect(x0, y0, w, h, ILI9341_RED);
-    }
 
     if (this->getName() == "timerUpBtn") {
         tft.fillTriangle(240, 95, 260, 55, 280, 95, ILI9341_WHITE);

--- a/src/button.cpp
+++ b/src/button.cpp
@@ -1,11 +1,4 @@
 #include "button.h"
-#include <Arduino.h>
-#include <Adafruit_ILI9341.h>
-#include "icons.h"
-#include "systemStatus.h"
-
-extern Adafruit_ILI9341 tft;
-extern SystemStatus systemStatus;
 
 Button::Button() {}
 Button::Button(String name, uint16_t x0, uint16_t y0, uint16_t w, uint16_t h, String buttonText, uint16_t textOffsetLeft, uint16_t textOffsetTop)
@@ -20,21 +13,11 @@ Button::Button(String name, uint16_t x0, uint16_t y0, uint16_t w, uint16_t h, St
 {
     this->pressed = false;
     this->currentStatus = "none";
-    this->render();
-}
-
-void Button::render()
-{
-}
-
-void Button::renderPressed()
-{
 }
 
 bool Button::isPressed(int x, int y)
 {
     if ((x > this->x0 && x < (this->x0 + this->w)) && (y > this->y0 && (y < (this->y0 + this->h)))) {
-        this->renderPressed();
         return true;
     }
 

--- a/src/button.cpp
+++ b/src/button.cpp
@@ -25,31 +25,6 @@ Button::Button(String name, uint16_t x0, uint16_t y0, uint16_t w, uint16_t h, St
 
 void Button::render()
 {
-
-    if (this->getName() == "terminateYesBtn") {
-        tft.drawRect(x0, y0, w, h, ILI9341_WHITE);
-
-        tft.fillRect(x0 + 1, y0 + 1, w - 2, h - 2, ILI9341_RED);
-
-        tft.setCursor(x0 + textOffsetLeft, y0 + textOffsetTop);
-        tft.setTextColor(ILI9341_WHITE);
-        tft.setTextSize(2);
-
-        tft.print(buttonText);
-    }
-
-    if (this->getName() == "terminateNoBtn") {
-        tft.drawRect(x0, y0, w, h, ILI9341_WHITE);
-
-        tft.fillRect(x0 + 1, y0 + 1, w - 2, h - 2, ILI9341_OLIVE);
-
-        tft.setCursor(x0 + textOffsetLeft, y0 + textOffsetTop);
-        tft.setTextColor(ILI9341_WHITE);
-        tft.setTextSize(3);
-
-        tft.print(buttonText);
-    }
-
     if (this->getName() == "timerUpBtn") {
         tft.fillTriangle(240, 95, 260, 55, 280, 95, ILI9341_RED);
         tft.drawTriangle(240, 95, 260, 55, 280, 95, ILI9341_LIGHTGREY);

--- a/src/button.cpp
+++ b/src/button.cpp
@@ -1,6 +1,5 @@
 #include "button.h"
 
-Button::Button() {}
 Button::Button(String name, uint16_t x0, uint16_t y0, uint16_t w, uint16_t h, String buttonText, uint16_t textOffsetLeft, uint16_t textOffsetTop)
     : name { name }
     , x0 { x0 }
@@ -11,7 +10,6 @@ Button::Button(String name, uint16_t x0, uint16_t y0, uint16_t w, uint16_t h, St
     , textOffsetLeft { textOffsetLeft }
     , textOffsetTop { textOffsetTop }
 {
-    this->pressed = false;
     this->currentStatus = "none";
 }
 
@@ -19,10 +17,6 @@ bool Button::isPressed(int x, int y)
 {
     if ((x > this->x0 && x < (this->x0 + this->w)) && (y > this->y0 && (y < (this->y0 + this->h)))) {
         return true;
-    }
-
-    if (this->pressed) {
-        this->setStatus("none");
     }
 
     return false;

--- a/src/button.cpp
+++ b/src/button.cpp
@@ -25,32 +25,6 @@ Button::Button(String name, uint16_t x0, uint16_t y0, uint16_t w, uint16_t h, St
 
 void Button::render()
 {
-    if (this->getName() == "wifiOnBtn") {
-        tft.drawRect(x0, y0, w, h, ILI9341_WHITE);
-        tft.fillRect(x0 + 1, y0 + 1, w - 2, h - 2, ILI9341_OLIVE);
-        tft.setCursor(x0 + textOffsetLeft, y0 + textOffsetTop);
-        tft.setTextColor(ILI9341_WHITE);
-        tft.setTextSize(3);
-        tft.print(buttonText);
-    }
-
-    if (this->getName() == "wifiOffBtn") {
-        tft.drawRect(x0, y0, w, h, ILI9341_WHITE);
-        tft.fillRect(x0 + 1, y0 + 1, w - 2, h - 2, ILI9341_OLIVE);
-        tft.setCursor(x0 + textOffsetLeft, y0 + textOffsetTop);
-        tft.setTextColor(ILI9341_WHITE);
-        tft.setTextSize(3);
-        tft.print(buttonText);
-    }
-
-    if (this->getName() == "wifiOkBtn") {
-        tft.drawRect(x0, y0, w, h, ILI9341_WHITE);
-        tft.fillRect(x0 + 1, y0 + 1, w - 2, h - 2, ILI9341_OLIVE);
-        tft.setCursor(x0 + textOffsetLeft, y0 + textOffsetTop);
-        tft.setTextColor(ILI9341_WHITE);
-        tft.setTextSize(3);
-        tft.print(buttonText);
-    }
 }
 
 void Button::renderPressed()

--- a/src/button.cpp
+++ b/src/button.cpp
@@ -51,43 +51,6 @@ void Button::render()
         tft.setTextSize(3);
         tft.print(buttonText);
     }
-
-    if (this->getName() == "tempFahrenheitBtn") {
-        tft.drawRect(x0, y0, w, h, ILI9341_WHITE);
-
-        if (systemStatus.getTempUnit() == 'F') {
-            tft.fillRect(x0 + 1, y0 + 1, w - 2, h - 2, ILI9341_OLIVE);
-        } else {
-            tft.fillRect(x0 + 1, y0 + 1, w - 2, h - 2, ILI9341_BLACK);
-        }
-        tft.setCursor(x0 + textOffsetLeft, y0 + textOffsetTop);
-        tft.setTextColor(ILI9341_WHITE);
-        tft.setTextSize(2);
-        tft.print(buttonText);
-    }
-
-    if (this->getName() == "tempCelsiusBtn") {
-        tft.drawRect(x0, y0, w, h, ILI9341_WHITE);
-
-        if (systemStatus.getTempUnit() == 'C') {
-            tft.fillRect(x0 + 1, y0 + 1, w - 2, h - 2, ILI9341_OLIVE);
-        } else {
-            tft.fillRect(x0 + 1, y0 + 1, w - 2, h - 2, ILI9341_BLACK);
-        }
-        tft.setCursor(x0 + textOffsetLeft, y0 + textOffsetTop);
-        tft.setTextColor(ILI9341_WHITE);
-        tft.setTextSize(2);
-        tft.print(buttonText);
-    }
-
-    if (this->getName() == "tempUnitOkBtn") {
-        tft.drawRect(x0, y0, w, h, ILI9341_WHITE);
-        tft.fillRect(x0 + 1, y0 + 1, w - 2, h - 2, ILI9341_OLIVE);
-        tft.setCursor(x0 + textOffsetLeft, y0 + textOffsetTop);
-        tft.setTextColor(ILI9341_WHITE);
-        tft.setTextSize(3);
-        tft.print(buttonText);
-    }
 }
 
 void Button::renderPressed()

--- a/src/button.cpp
+++ b/src/button.cpp
@@ -25,25 +25,6 @@ Button::Button(String name, uint16_t x0, uint16_t y0, uint16_t w, uint16_t h, St
 
 void Button::render()
 {
-    if (this->getName() == "timerUpBtn") {
-        tft.fillTriangle(240, 95, 260, 55, 280, 95, ILI9341_RED);
-        tft.drawTriangle(240, 95, 260, 55, 280, 95, ILI9341_LIGHTGREY);
-    }
-
-    if (this->getName() == "timerDownBtn") {
-        tft.fillTriangle(240, 170, 260, 130, 280, 170, ILI9341_RED);
-        tft.drawTriangle(240, 170, 260, 130, 280, 170, ILI9341_LIGHTGREY);
-    }
-
-    if (this->getName() == "timerOkBtn") {
-        tft.drawRect(x0, y0, w, h, ILI9341_WHITE);
-        tft.fillRect(x0 + 1, y0 + 1, w - 2, h - 2, ILI9341_OLIVE);
-        tft.setCursor(x0 + textOffsetLeft, y0 + textOffsetTop);
-        tft.setTextColor(ILI9341_WHITE);
-        tft.setTextSize(3);
-        tft.print(buttonText);
-    }
-
     if (this->getName() == "wifiOnBtn") {
         tft.drawRect(x0, y0, w, h, ILI9341_WHITE);
         tft.fillRect(x0 + 1, y0 + 1, w - 2, h - 2, ILI9341_OLIVE);

--- a/src/button.cpp
+++ b/src/button.cpp
@@ -26,30 +26,6 @@ Button::Button(String name, uint16_t x0, uint16_t y0, uint16_t w, uint16_t h, St
 void Button::render()
 {
 
-    if (this->getName() == "cancelScreenOkBtn") {
-        tft.drawRect(x0, y0, w, h, ILI9341_WHITE);
-
-        tft.fillRect(x0 + 1, y0 + 1, w - 2, h - 2, ILI9341_OLIVE);
-
-        tft.setCursor(x0 + textOffsetLeft, y0 + textOffsetTop);
-        tft.setTextColor(ILI9341_WHITE);
-        tft.setTextSize(3);
-
-        tft.print(buttonText);
-    }
-
-    if (this->getName() == "terminateBtn") {
-        tft.drawRect(x0, y0, w, h, ILI9341_WHITE);
-
-        tft.fillRect(x0 + 1, y0 + 1, w - 2, h - 2, ILI9341_RED);
-
-        tft.setCursor(x0 + textOffsetLeft, y0 + textOffsetTop);
-        tft.setTextColor(ILI9341_WHITE);
-        tft.setTextSize(2);
-
-        tft.print(buttonText);
-    }
-
     if (this->getName() == "terminateYesBtn") {
         tft.drawRect(x0, y0, w, h, ILI9341_WHITE);
 

--- a/src/button.h
+++ b/src/button.h
@@ -6,6 +6,9 @@
 class Button {
 
     String name;
+    String currentStatus;
+
+public:
     uint16_t x0;
     uint16_t y0;
     uint16_t w;
@@ -13,9 +16,7 @@ class Button {
     String buttonText;
     uint16_t textOffsetLeft;
     uint16_t textOffsetTop;
-    String currentStatus;
 
-public:
     bool pressed;
     Button();
     Button(String name, uint16_t x0, uint16_t y0, uint16_t w, uint16_t h, String buttonText, uint16_t textOffsetLeft, uint16_t textOffsetTop);

--- a/src/button.h
+++ b/src/button.h
@@ -21,9 +21,6 @@ public:
     Button();
     Button(String name, uint16_t x0, uint16_t y0, uint16_t w, uint16_t h, String buttonText, uint16_t textOffsetLeft, uint16_t textOffsetTop);
 
-    void render();
-    void renderPressed();
-
     String getName() { return this->name; }
 
     bool isPressed(int x, int y);

--- a/src/button.h
+++ b/src/button.h
@@ -17,8 +17,6 @@ public:
     uint16_t textOffsetLeft;
     uint16_t textOffsetTop;
 
-    bool pressed;
-    Button();
     Button(String name, uint16_t x0, uint16_t y0, uint16_t w, uint16_t h, String buttonText, uint16_t textOffsetLeft, uint16_t textOffsetTop);
 
     String getName() { return this->name; }

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -6,10 +6,10 @@ void Screen::renderButtons(bool forced)
 {
     for (auto it = buttons.begin(); it != buttons.end(); ++it) {
         Button& btn = *it;
-        if (btn.getStatus() == "pressed") {
-            this->renderButtonPressed(btn);
+        if (forced) {
+            this->renderButton(btn);
+        } else if (btn.getStatus() == "pressed") {
             btn.setStatus("none");
-        } else if (forced) {
             this->renderButton(btn);
         }
     }
@@ -27,7 +27,7 @@ void Screen::processTouch(int x, int y)
         }
 
         btn.setStatus("pressed");
+        this->renderButtonPressed(btn);
         this->handleButton(btn);
-        this->renderButtons();
     }
 }

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -27,7 +27,7 @@ void Screen::processTouch(int x, int y)
         }
 
         btn.setStatus("pressed");
-
         this->handleButton(btn);
+        this->renderButtons();
     }
 }

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -1,0 +1,33 @@
+#include <Particle.h>
+#include <Arduino.h>
+#include "screen.h"
+
+void Screen::renderButtons(bool forced)
+{
+    for (auto it = buttons.begin(); it != buttons.end(); ++it) {
+        Button& btn = *it;
+        if (btn.getStatus() == "pressed") {
+            this->renderButtonPressed(btn);
+            btn.setStatus("none");
+        } else if (forced) {
+            this->renderButton(btn);
+        }
+    }
+}
+
+void Screen::processTouch(int x, int y)
+{
+    for (auto it = buttons.begin(); it != buttons.end(); ++it) {
+        Button& btn = *it;
+        if (!btn.isPressed(x, y)) {
+            continue;
+        }
+        if (btn.getStatus() != "none") {
+            continue;
+        }
+
+        btn.setStatus("pressed");
+
+        this->handleButton(btn);
+    }
+}

--- a/src/screen.h
+++ b/src/screen.h
@@ -1,0 +1,22 @@
+#ifndef SCREEN_H
+#define SCREEN_H
+
+#include <vector>
+#include "button.h"
+
+class Screen {
+protected:
+    std::vector<Button> buttons;
+
+public:
+    virtual String getName();
+    virtual void render();
+    virtual void renderButton(Button& btn);
+    virtual void renderButtonPressed(Button& btn);
+    virtual void handleButton(Button& btn);
+
+    void renderButtons(bool forced = false);
+    void processTouch(int x, int y);
+};
+
+#endif

--- a/src/screen_manager.cpp
+++ b/src/screen_manager.cpp
@@ -85,17 +85,3 @@ void ScreenManager::renderButtons(bool forced)
         current->renderButtons(forced);
     }
 }
-
-void ScreenManager::clearButtons()
-{
-    Button blankBtn("blankBtn", -1, -1, -1, -1, "", -1, -1);
-
-    tft.fillScreen(ILI9341_BLACK);
-
-    buttons[0] = blankBtn;
-    buttons[1] = blankBtn;
-    buttons[2] = blankBtn;
-    buttons[3] = blankBtn;
-    buttons[4] = blankBtn;
-    buttons[5] = blankBtn;
-}

--- a/src/screen_manager.cpp
+++ b/src/screen_manager.cpp
@@ -10,55 +10,8 @@ extern float fanSpeedPercent;
 
 void ScreenManager::homeScreen()
 {
-    this->clearButtons();
-    currentScreen = "homeScreen";
-
-    if (systemStatus.getDayCount() == -1) {
-
-        tft.setTextColor(ILI9341_LIGHTGREY);
-        tft.setTextSize(2);
-
-        tft.setCursor(126, 15);
-        tft.print("Hi,");
-
-        tft.setCursor(75, 40);
-        tft.print("I'm Tomatotent.");
-
-        tft.drawBitmap(110, 65, tomato_filled_100, 100, 100, ILI9341_RED);
-
-        Button startGrowBtn("startGrowBtn", 35, 180, 250, 38, "Start a Grow", 18, 8);
-        buttons[0] = startGrowBtn;
-
-    } else { // a grow is in progress
-
-        tft.drawRect(20, 180, 250, 38, ILI9341_BLACK);
-
-        systemStatus.drawDayCounter();
-
-        Button dayCounterBtn("dayCounterBtn", 20, 180, 250, 38, "", 18, 8);
-        buttons[1] = dayCounterBtn;
-
-        Button timerBtn("timerBtn", 10, 10, 115, 25, "", 18, 8);
-        buttons[2] = timerBtn;
-
-        Button fanBtn("fanBtn", 145, 10, 115, 35, "", 18, 8);
-        buttons[3] = fanBtn;
-
-        Button tempBtn("tempBtn", 50, 55, 115, 35, "", 18, 8);
-        buttons[4] = tempBtn;
-
-        tft.drawBitmap(165, 4, fan_36, 36, 36, ILI9341_WHITE);
-
-        systemStatus.drawTimerStatus();
-        systemStatus.check_fan();
-        tent.drawStats(systemStatus.getTempUnit());
-
-        if (tent.getGrowLightStatus() == "LOW") {
-            tent.drawDimmedIndicator();
-        }
-    }
-    Button wifiBtn("wifiBtn", 260, 0, 60, 30, "", 18, 8);
-    buttons[5] = wifiBtn;
+    current = new HomeScreen();
+    current->render();
 }
 
 void ScreenManager::growStartedScreen()

--- a/src/screen_manager.cpp
+++ b/src/screen_manager.cpp
@@ -8,6 +8,7 @@
 #include "screens/temp_unit.h"
 #include "screens/grow_started.h"
 #include "screens/wifi_splash.h"
+#include "screens/wifi.h"
 
 extern Adafruit_ILI9341 tft;
 extern SystemStatus systemStatus;
@@ -52,17 +53,9 @@ void ScreenManager::timerScreen()
 
 void ScreenManager::wifiScreen()
 {
-    this->clearButtons();
-    currentScreen = "wifiScreen";
-
-    Button wifiOnBtn("wifiOnBtn", 20, 40, 250, 38, "On", 110, 8);
-    buttons[0] = wifiOnBtn;
-
-    Button wifiOffBtn("wifiOffBtn", 20, 100, 250, 38, "Off", 110, 8);
-    buttons[1] = wifiOffBtn;
-
-    Button wifiOkBtn("wifiOkBtn", 20, 180, 250, 38, "Ok", 110, 8);
-    buttons[2] = wifiOkBtn;
+    current = new WifiScreen();
+    currentScreen = current->getName();
+    current->render();
 }
 
 void ScreenManager::wifiSplashScreen()

--- a/src/screen_manager.cpp
+++ b/src/screen_manager.cpp
@@ -6,6 +6,7 @@
 #include "screens/timer.h"
 #include "screens/fan.h"
 #include "screens/temp_unit.h"
+#include "screens/grow_started.h"
 
 extern Adafruit_ILI9341 tft;
 extern SystemStatus systemStatus;
@@ -22,20 +23,9 @@ void ScreenManager::homeScreen()
 
 void ScreenManager::growStartedScreen()
 {
-    this->clearButtons();
-    currentScreen = "growStartedScreen";
-
-    tft.fillScreen(ILI9341_OLIVE);
-
-    tft.setTextColor(ILI9341_WHITE);
-    tft.setTextSize(3);
-
-    tft.setCursor(50, 30);
-    tft.print("Your Grow");
-    tft.setCursor(60, 90);
-    tft.print("has started!");
-
-    tft.drawBitmap(124, 160, plant_filled_72x72, 72, 72, ILI9341_WHITE);
+    current = new GrowStartedScreen();
+    currentScreen = current->getName();
+    current->render();
 }
 
 void ScreenManager::cancelScreen()

--- a/src/screen_manager.cpp
+++ b/src/screen_manager.cpp
@@ -3,6 +3,7 @@
 #include "tent.h"
 #include "screens/cancel.h"
 #include "screens/cancel_confirm.h"
+#include "screens/timer.h"
 
 extern Adafruit_ILI9341 tft;
 extern SystemStatus systemStatus;
@@ -51,36 +52,9 @@ void ScreenManager::cancelConfirmationScreen()
 
 void ScreenManager::timerScreen()
 {
-    this->clearButtons();
-    currentScreen = "timerScreen";
-
-    tft.setCursor(20, 8);
-    tft.setTextColor(ILI9341_GREEN);
-    tft.setTextSize(2);
-    tft.print("Light Timer");
-
-    int dayDuration = systemStatus.getDayDuration();
-
-    tft.setTextColor(ILI9341_WHITE);
-    tft.setCursor(10, 70);
-    tft.print(String(dayDuration / 60) + " Hours ON");
-
-    int nightDuration = (24 * 60) - dayDuration;
-    tft.setCursor(10, 140);
-    tft.print(String(nightDuration / 60) + " Hours OFF");
-
-    Button timerUpBtn("timerUpBtn", 240, 50, 40, 40, "", 0, 0);
-    buttons[0] = timerUpBtn;
-
-    Button timerDownBtn("timerDownBtn", 240, 130, 40, 40, "", 0, 0);
-    buttons[1] = timerDownBtn;
-
-    Button timerOkBtn("timerOkBtn", 20, 180, 250, 38, "Ok", 110, 8);
-    buttons[2] = timerOkBtn;
-
-    if (tent.getGrowLightStatus() == "LOW") {
-        tent.drawDimmedIndicator();
-    }
+    current = new TimerScreen();
+    currentScreen = current->getName();
+    current->render();
 }
 
 void ScreenManager::wifiScreen()

--- a/src/screen_manager.cpp
+++ b/src/screen_manager.cpp
@@ -5,6 +5,7 @@
 #include "screens/cancel_confirm.h"
 #include "screens/timer.h"
 #include "screens/fan.h"
+#include "screens/temp_unit.h"
 
 extern Adafruit_ILI9341 tft;
 extern SystemStatus systemStatus;
@@ -115,28 +116,16 @@ void ScreenManager::fanScreen()
 
 void ScreenManager::tempUnitScreen()
 {
-    this->clearButtons();
-    currentScreen = "tempUnitScreen";
-
-    tft.drawBitmap(20, 4, thermometer_36, 36, 36, ILI9341_WHITE);
-
-    tft.setCursor(60, 8);
-    tft.setTextColor(ILI9341_GREEN);
-    tft.setTextSize(2);
-    tft.print("Temperature Unit");
-
-    Button tempFahrenheitBtn("tempFahrenheitBtn", 80, 70, 150, 38, "Fahrenheit", 20, 11);
-    buttons[0] = tempFahrenheitBtn;
-
-    Button tempCelsiusBtn("tempCelsiusBtn", 80, 140, 150, 38, "Celsius", 40, 11);
-    buttons[1] = tempCelsiusBtn;
+    current = new TempUnitScreen();
+    currentScreen = current->getName();
+    current->render();
 }
 
 void ScreenManager::renderButtons(bool forced)
 {
-    if (!current)
-        return;
-    current->renderButtons(forced);
+    if (current) {
+        current->renderButtons(forced);
+    }
 }
 
 void ScreenManager::clearButtons()

--- a/src/screen_manager.cpp
+++ b/src/screen_manager.cpp
@@ -4,6 +4,7 @@
 #include "screens/cancel.h"
 #include "screens/cancel_confirm.h"
 #include "screens/timer.h"
+#include "screens/fan.h"
 
 extern Adafruit_ILI9341 tft;
 extern SystemStatus systemStatus;
@@ -107,32 +108,9 @@ void ScreenManager::wifiSetupScreen()
 
 void ScreenManager::fanScreen()
 {
-    this->clearButtons();
-    currentScreen = "fanScreen";
-
-    tft.drawBitmap(20, 4, fan_36, 36, 36, ILI9341_WHITE);
-
-    tft.setCursor(60, 8);
-    tft.setTextColor(ILI9341_GREEN);
-    tft.setTextSize(2);
-    tft.print("Speed");
-
-    Button fanAutoBtn("fanAutoBtn", 20, 65, 150, 38, "Automatic", 20, 11);
-    buttons[0] = fanAutoBtn;
-
-    Button fanManualBtn("fanManualBtn", 20, 115, 150, 38, "Manual", 40, 11);
-    buttons[1] = fanManualBtn;
-
-    Button fanUpBtn("fanUpBtn", 240, 50, 40, 40, "", 0, 0);
-    buttons[2] = fanUpBtn;
-
-    Button fanDownBtn("fanDownBtn", 240, 110, 40, 40, "", 0, 0);
-    buttons[3] = fanDownBtn;
-
-    Button fanOkBtn("fanOkBtn", 20, 180, 250, 38, "Ok", 110, 8);
-    buttons[4] = fanOkBtn;
-
-    systemStatus.drawFanSpeed();
+    current = new FanScreen();
+    currentScreen = current->getName();
+    current->render();
 }
 
 void ScreenManager::tempUnitScreen()

--- a/src/screen_manager.cpp
+++ b/src/screen_manager.cpp
@@ -12,6 +12,7 @@ extern float fanSpeedPercent;
 void ScreenManager::homeScreen()
 {
     current = new HomeScreen();
+    currentScreen = current->getName();
     current->render();
 }
 
@@ -36,6 +37,7 @@ void ScreenManager::growStartedScreen()
 void ScreenManager::cancelScreen()
 {
     current = new CancelScreen();
+    currentScreen = current->getName();
     current->render();
 }
 

--- a/src/screen_manager.cpp
+++ b/src/screen_manager.cpp
@@ -2,6 +2,7 @@
 #include "systemStatus.h"
 #include "tent.h"
 #include "screens/cancel.h"
+#include "screens/cancel_confirm.h"
 
 extern Adafruit_ILI9341 tft;
 extern SystemStatus systemStatus;
@@ -43,19 +44,9 @@ void ScreenManager::cancelScreen()
 
 void ScreenManager::cancelConfirmationScreen()
 {
-    this->clearButtons();
-    currentScreen = "cancelConfirmationScreen";
-
-    tft.setCursor(10, 50);
-    tft.setTextColor(ILI9341_RED);
-    tft.setTextSize(3);
-    tft.print("Really Terminate?");
-
-    Button terminateYesBtn("terminateYesBtn", 70, 120, 180, 28, "Yes", 78, 7);
-    buttons[0] = terminateYesBtn;
-
-    Button terminateNoBtn("terminateNoBtn", 70, 180, 180, 38, "No", 75, 8);
-    buttons[1] = terminateNoBtn;
+    current = new CancelConfirmScreen();
+    currentScreen = current->getName();
+    current->render();
 }
 
 void ScreenManager::timerScreen()

--- a/src/screen_manager.cpp
+++ b/src/screen_manager.cpp
@@ -7,6 +7,7 @@
 #include "screens/fan.h"
 #include "screens/temp_unit.h"
 #include "screens/grow_started.h"
+#include "screens/wifi_splash.h"
 
 extern Adafruit_ILI9341 tft;
 extern SystemStatus systemStatus;
@@ -64,37 +65,11 @@ void ScreenManager::wifiScreen()
     buttons[2] = wifiOkBtn;
 }
 
-void ScreenManager::wifiSetupScreen()
+void ScreenManager::wifiSplashScreen()
 {
-    this->clearButtons();
-    currentScreen = "wifiScreen";
-
-    tft.drawBitmap(18, 5, iconWifi_24x24, 24, 24, ILI9341_WHITE);
-
-    tft.setCursor(50, 10);
-    tft.setTextColor(ILI9341_GREEN);
-    tft.setTextSize(3);
-    tft.print("WiFi Setup");
-
-    tft.setTextColor(ILI9341_WHITE);
-    tft.setTextSize(1);
-    tft.setCursor(20, 50);
-    tft.print("Use a SmartPhone, Tablet or Computer");
-    tft.setCursor(20, 70);
-    tft.print("Go to WiFi settings, scan for Networks.");
-    tft.setCursor(20, 90);
-    tft.print("Connect to the Network called TomatoTent-xxxx.");
-    tft.setCursor(20, 110);
-    tft.print("Open a Web Browser (Safari, Chrome, IE).");
-    tft.setCursor(20, 130);
-    tft.print("Navigate to http://192.168.0.1");
-    tft.setCursor(20, 150);
-    tft.print("Follow the instructions there.");
-
-    tft.setCursor(20, 200);
-    tft.setTextSize(2);
-    tft.setTextColor(ILI9341_GREEN);
-    tft.print("community.tomatotent.de");
+    current = new WifiSplashScreen();
+    currentScreen = current->getName();
+    current->render();
 }
 
 void ScreenManager::fanScreen()

--- a/src/screen_manager.cpp
+++ b/src/screen_manager.cpp
@@ -1,6 +1,7 @@
 #include "screen_manager.h"
 #include "systemStatus.h"
 #include "tent.h"
+#include "screens/cancel.h"
 
 extern Adafruit_ILI9341 tft;
 extern SystemStatus systemStatus;
@@ -34,35 +35,8 @@ void ScreenManager::growStartedScreen()
 
 void ScreenManager::cancelScreen()
 {
-    this->clearButtons();
-    currentScreen = "cancelScreen";
-
-    tft.setCursor(20, 70);
-    tft.setTextColor(ILI9341_WHITE);
-    tft.setTextSize(2);
-    tft.print("Your grow is " + String(systemStatus.getDayCount() - 1) + " days old.");
-
-    tft.setCursor(20, 100);
-    tft.print("Most Cannabis is ready");
-
-    tft.setCursor(20, 120);
-    tft.print("after about 110 days.");
-
-    /* Include if you want to know your free memory */
-    //tft.setTextSize(1);
-    //tft.setCursor(50,140);
-    //uint32_t freemem = System.freeMemory();
-    //tft.print(freemem);
-
-    Button cancelScreenOkBtn("cancelScreenOkBtn", 20, 180, 250, 38, "Ok", 110, 8);
-    buttons[0] = cancelScreenOkBtn;
-
-    Button terminateBtn("terminateBtn", 120, 10, 185, 28, "Terminate Grow", 10, 7);
-    buttons[1] = terminateBtn;
-
-    if (tent.getGrowLightStatus() == "LOW") {
-        tent.drawDimmedIndicator();
-    }
+    current = new CancelScreen();
+    current->render();
 }
 
 void ScreenManager::cancelConfirmationScreen()

--- a/src/screen_manager.cpp
+++ b/src/screen_manager.cpp
@@ -262,15 +262,9 @@ void ScreenManager::tempUnitScreen()
 
 void ScreenManager::renderButtons(bool forced)
 {
-    uint8_t d { 0 };
-    for (d = 0; d < (sizeof(buttons) / sizeof(buttons[0])); ++d) {
-        if (buttons[d].getStatus() == "pressed") {
-            buttons[d].render();
-            buttons[d].setStatus("none");
-        } else if (forced) {
-            buttons[d].render();
-        }
-    }
+    if (!current)
+        return;
+    current->renderButtons(forced);
 }
 
 void ScreenManager::clearButtons()

--- a/src/screen_manager.h
+++ b/src/screen_manager.h
@@ -4,13 +4,16 @@
 #include <Particle.h>
 #include <Arduino.h>
 
-#include <button.h>
+#include "button.h"
+#include "screen.h"
+#include "screens/home.h"
 
 class ScreenManager {
 
     void clearButtons();
 
 public:
+    Screen* current = new HomeScreen();
     Button buttons[6];
     String currentScreen = "homeScreen";
 

--- a/src/screen_manager.h
+++ b/src/screen_manager.h
@@ -27,7 +27,7 @@ public:
     void cancelConfirmationScreen();
     void timerScreen();
     void wifiScreen();
-    void wifiSetupScreen();
+    void wifiSplashScreen();
     void fanScreen();
     void tempUnitScreen();
 };

--- a/src/screen_manager.h
+++ b/src/screen_manager.h
@@ -9,12 +9,8 @@
 #include "screens/home.h"
 
 class ScreenManager {
-
-    void clearButtons();
-
 public:
     Screen* current = new HomeScreen();
-    Button buttons[6];
     String currentScreen = "homeScreen";
 
     ScreenManager() {};

--- a/src/screens/cancel.cpp
+++ b/src/screens/cancel.cpp
@@ -1,0 +1,82 @@
+#include "cancel.h"
+#include "systemStatus.h"
+#include "icons.h"
+#include "tent.h"
+#include <Adafruit_ILI9341.h>
+
+extern Adafruit_ILI9341 tft;
+extern SystemStatus systemStatus;
+extern Tent tent;
+
+void CancelScreen::render()
+{
+    tft.fillScreen(ILI9341_BLACK);
+
+    tft.setCursor(20, 70);
+    tft.setTextColor(ILI9341_WHITE);
+    tft.setTextSize(2);
+    tft.print("Your grow is " + String(systemStatus.getDayCount() - 1) + " days old.");
+
+    tft.setCursor(20, 100);
+    tft.print("Most Cannabis is ready");
+
+    tft.setCursor(20, 120);
+    tft.print("after about 110 days.");
+
+    /* Include if you want to know your free memory */
+    //tft.setTextSize(1);
+    //tft.setCursor(50,140);
+    //uint32_t freemem = System.freeMemory();
+    //tft.print(freemem);
+
+    buttons.push_back(Button("cancelScreenOkBtn", 20, 180, 250, 38, "Ok", 110, 8));
+    buttons.push_back(Button("terminateBtn", 120, 10, 185, 28, "Terminate Grow", 10, 7));
+    renderButtons(true);
+
+    if (tent.getGrowLightStatus() == "LOW") {
+        tent.drawDimmedIndicator();
+    }
+}
+
+void CancelScreen::renderButton(Button& btn)
+{
+    uint16_t x0 = btn.x0, y0 = btn.y0, w = btn.w, h = btn.h, textOffsetLeft = btn.textOffsetLeft, textOffsetTop = btn.textOffsetTop;
+    String buttonText = btn.buttonText;
+
+    if (btn.getName() == "terminateBtn") {
+        tft.drawRect(x0, y0, w, h, ILI9341_WHITE);
+
+        tft.fillRect(x0 + 1, y0 + 1, w - 2, h - 2, ILI9341_RED);
+
+        tft.setCursor(x0 + textOffsetLeft, y0 + textOffsetTop);
+        tft.setTextColor(ILI9341_WHITE);
+        tft.setTextSize(2);
+
+        tft.print(buttonText);
+
+    } else if (btn.getName() == "cancelScreenOkBtn") {
+        tft.drawRect(x0, y0, w, h, ILI9341_WHITE);
+
+        tft.fillRect(x0 + 1, y0 + 1, w - 2, h - 2, ILI9341_OLIVE);
+
+        tft.setCursor(x0 + textOffsetLeft, y0 + textOffsetTop);
+        tft.setTextColor(ILI9341_WHITE);
+        tft.setTextSize(3);
+
+        tft.print(buttonText);
+    }
+}
+
+void CancelScreen::renderButtonPressed(Button& btn)
+{
+}
+
+void CancelScreen::handleButton(Button& btn)
+{
+    if (btn.getName() == "terminateBtn") {
+        screenManager.cancelConfirmationScreen();
+
+    } else if (btn.getName() == "cancelScreenOkBtn") {
+        screenManager.homeScreen();
+    }
+}

--- a/src/screens/cancel.h
+++ b/src/screens/cancel.h
@@ -1,0 +1,14 @@
+#ifndef CANCELSCREEN_H
+#define CANCELSCREEN_H
+
+#include "../screen.h"
+
+class CancelScreen: public Screen {
+public:
+    String getName() { return "cancelScreen"; }
+    void render();
+    void renderButton(Button& btn);
+    void renderButtonPressed(Button& btn);
+    void handleButton(Button &btn);
+};
+#endif

--- a/src/screens/cancel_confirm.cpp
+++ b/src/screens/cancel_confirm.cpp
@@ -1,0 +1,74 @@
+#include "cancel_confirm.h"
+#include "systemStatus.h"
+#include "icons.h"
+#include "tent.h"
+#include <Adafruit_ILI9341.h>
+
+extern Adafruit_ILI9341 tft;
+extern SystemStatus systemStatus;
+extern Tent tent;
+extern Timer minutelyTicker, draw_temp_home;
+
+void CancelConfirmScreen::render()
+{
+    tft.fillScreen(ILI9341_BLACK);
+
+    tft.setCursor(10, 50);
+    tft.setTextColor(ILI9341_RED);
+    tft.setTextSize(3);
+    tft.print("Really Terminate?");
+
+    buttons.push_back(Button("terminateYesBtn", 70, 120, 180, 28, "Yes", 78, 7));
+    buttons.push_back(Button("terminateNoBtn", 70, 180, 180, 38, "No", 75, 8));
+
+    renderButtons(true);
+}
+
+void CancelConfirmScreen::renderButton(Button& btn)
+{
+    uint16_t x0 = btn.x0, y0 = btn.y0, w = btn.w, h = btn.h, textOffsetLeft = btn.textOffsetLeft, textOffsetTop = btn.textOffsetTop;
+    String buttonText = btn.buttonText;
+
+    if (btn.getName() == "terminateYesBtn") {
+        tft.drawRect(x0, y0, w, h, ILI9341_WHITE);
+
+        tft.fillRect(x0 + 1, y0 + 1, w - 2, h - 2, ILI9341_RED);
+
+        tft.setCursor(x0 + textOffsetLeft, y0 + textOffsetTop);
+        tft.setTextColor(ILI9341_WHITE);
+        tft.setTextSize(2);
+
+        tft.print(buttonText);
+
+    } else if (btn.getName() == "terminateNoBtn") {
+        tft.drawRect(x0, y0, w, h, ILI9341_WHITE);
+
+        tft.fillRect(x0 + 1, y0 + 1, w - 2, h - 2, ILI9341_OLIVE);
+
+        tft.setCursor(x0 + textOffsetLeft, y0 + textOffsetTop);
+        tft.setTextColor(ILI9341_WHITE);
+        tft.setTextSize(3);
+
+        tft.print(buttonText);
+    }
+}
+
+void CancelConfirmScreen::renderButtonPressed(Button& btn)
+{
+}
+
+void CancelConfirmScreen::handleButton(Button& btn)
+{
+    if (btn.getName() == "terminateYesBtn") {
+        tent.growLight("OFF");
+        draw_temp_home.stop();
+        tent.fan("OFF");
+        minutelyTicker.stop();
+
+        systemStatus.init();
+        screenManager.homeScreen();
+
+    } else if (btn.getName() == "terminateNoBtn") {
+        screenManager.homeScreen();
+    }
+}

--- a/src/screens/cancel_confirm.h
+++ b/src/screens/cancel_confirm.h
@@ -1,0 +1,14 @@
+#ifndef CANCELCONFIRMSCREEN_H
+#define CANCELCONFIRMSCREEN_H
+
+#include "../screen.h"
+
+class CancelConfirmScreen: public Screen {
+public:
+    String getName() { return "cancelConfirmScreen"; }
+    void render();
+    void renderButton(Button& btn);
+    void renderButtonPressed(Button& btn);
+    void handleButton(Button &btn);
+};
+#endif

--- a/src/screens/fan.cpp
+++ b/src/screens/fan.cpp
@@ -93,18 +93,21 @@ void FanScreen::handleButton(Button& btn)
 {
     if (btn.getName() == "fanAutoBtn") {
         systemStatus.setFanAutoMode(true);
-        renderButtons(true);
+        renderButton(buttons[0]);
+        renderButton(buttons[1]);
         systemStatus.check_fan();
 
     } else if (btn.getName() == "fanManualBtn") {
         systemStatus.setFanAutoMode(false);
-        renderButtons(true);
+        renderButton(buttons[0]);
+        renderButton(buttons[1]);
         systemStatus.check_fan();
 
     } else if (btn.getName() == "fanUpBtn") {
         float fanSpeedPercent = systemStatus.getFanSpeed();
         systemStatus.setFanAutoMode(false);
-        renderButtons(true);
+        renderButton(buttons[0]);
+        renderButton(buttons[1]);
 
         if (fanSpeedPercent < 100) {
             fanSpeedPercent += 5;
@@ -115,7 +118,8 @@ void FanScreen::handleButton(Button& btn)
     } else if (btn.getName() == "fanDownBtn") {
         float fanSpeedPercent = systemStatus.getFanSpeed();
         systemStatus.setFanAutoMode(false);
-        renderButtons(true);
+        renderButton(buttons[0]);
+        renderButton(buttons[1]);
 
         if (fanSpeedPercent > 0) {
             fanSpeedPercent -= 5;

--- a/src/screens/fan.cpp
+++ b/src/screens/fan.cpp
@@ -83,6 +83,7 @@ void FanScreen::renderButtonPressed(Button& btn)
 {
     if (btn.getName() == "fanUpBtn") {
         tft.fillTriangle(240, 95, 260, 55, 280, 95, ILI9341_WHITE);
+
     } else if (btn.getName() == "fanDownBtn") {
         tft.fillTriangle(240, 110, 260, 150, 280, 110, ILI9341_WHITE);
     }
@@ -91,18 +92,18 @@ void FanScreen::renderButtonPressed(Button& btn)
 void FanScreen::handleButton(Button& btn)
 {
     if (btn.getName() == "fanAutoBtn") {
-        systemStatus.setFanAutoMode(1);
-        screenManager.renderButtons(true);
+        systemStatus.setFanAutoMode(true);
+        renderButtons(true);
         systemStatus.check_fan();
 
     } else if (btn.getName() == "fanManualBtn") {
-        systemStatus.setFanAutoMode(0);
-        screenManager.renderButtons(true);
+        systemStatus.setFanAutoMode(false);
+        renderButtons(true);
         systemStatus.check_fan();
 
     } else if (btn.getName() == "fanUpBtn") {
         float fanSpeedPercent = systemStatus.getFanSpeed();
-        systemStatus.setFanAutoMode(0);
+        systemStatus.setFanAutoMode(false);
         renderButtons(true);
 
         if (fanSpeedPercent < 100) {
@@ -113,7 +114,7 @@ void FanScreen::handleButton(Button& btn)
 
     } else if (btn.getName() == "fanDownBtn") {
         float fanSpeedPercent = systemStatus.getFanSpeed();
-        systemStatus.setFanAutoMode(0);
+        systemStatus.setFanAutoMode(false);
         renderButtons(true);
 
         if (fanSpeedPercent > 0) {

--- a/src/screens/fan.cpp
+++ b/src/screens/fan.cpp
@@ -1,0 +1,128 @@
+#include "fan.h"
+#include "systemStatus.h"
+#include "icons.h"
+#include "tent.h"
+#include <Adafruit_ILI9341.h>
+
+extern Adafruit_ILI9341 tft;
+extern SystemStatus systemStatus;
+extern Tent tent;
+
+void FanScreen::render()
+{
+    tft.fillScreen(ILI9341_BLACK);
+
+    tft.drawBitmap(20, 4, fan_36, 36, 36, ILI9341_WHITE);
+
+    tft.setCursor(60, 8);
+    tft.setTextColor(ILI9341_GREEN);
+    tft.setTextSize(2);
+    tft.print("Speed");
+
+    buttons.push_back(Button("fanAutoBtn", 20, 65, 150, 38, "Automatic", 20, 11));
+    buttons.push_back(Button("fanManualBtn", 20, 115, 150, 38, "Manual", 40, 11));
+    buttons.push_back(Button("fanUpBtn", 240, 50, 40, 40, "", 0, 0));
+    buttons.push_back(Button("fanDownBtn", 240, 110, 40, 40, "", 0, 0));
+    buttons.push_back(Button("fanOkBtn", 20, 180, 250, 38, "Ok", 110, 8));
+
+    renderButtons(true);
+
+    systemStatus.drawFanSpeed();
+}
+
+void FanScreen::renderButton(Button& btn)
+{
+    uint16_t x0 = btn.x0, y0 = btn.y0, w = btn.w, h = btn.h, textOffsetLeft = btn.textOffsetLeft, textOffsetTop = btn.textOffsetTop;
+    String buttonText = btn.buttonText;
+
+    if (btn.getName() == "fanAutoBtn") {
+        tft.drawRect(x0, y0, w, h, ILI9341_WHITE);
+
+        if (systemStatus.getFanAutoMode()) {
+            tft.fillRect(x0 + 1, y0 + 1, w - 2, h - 2, ILI9341_OLIVE);
+        } else {
+            tft.fillRect(x0 + 1, y0 + 1, w - 2, h - 2, ILI9341_BLACK);
+        }
+        tft.setCursor(x0 + textOffsetLeft, y0 + textOffsetTop);
+        tft.setTextColor(ILI9341_WHITE);
+        tft.setTextSize(2);
+        tft.print(buttonText);
+
+    } else if (btn.getName() == "fanManualBtn") {
+        tft.drawRect(x0, y0, w, h, ILI9341_WHITE);
+
+        if (!systemStatus.getFanAutoMode()) {
+            tft.fillRect(x0 + 1, y0 + 1, w - 2, h - 2, ILI9341_OLIVE);
+        } else {
+            tft.fillRect(x0 + 1, y0 + 1, w - 2, h - 2, ILI9341_BLACK);
+        }
+        tft.setCursor(x0 + textOffsetLeft, y0 + textOffsetTop);
+        tft.setTextColor(ILI9341_WHITE);
+        tft.setTextSize(2);
+        tft.print(buttonText);
+
+    } else if (btn.getName() == "fanUpBtn") {
+        tft.fillTriangle(240, 95, 260, 55, 280, 95, ILI9341_RED);
+        tft.drawTriangle(240, 95, 260, 55, 280, 95, ILI9341_LIGHTGREY);
+
+    } else if (btn.getName() == "fanDownBtn") {
+        tft.fillTriangle(240, 110, 260, 150, 280, 110, ILI9341_RED);
+        tft.drawTriangle(240, 110, 260, 150, 280, 110, ILI9341_LIGHTGREY);
+
+    } else if (btn.getName() == "fanOkBtn") {
+        tft.drawRect(x0, y0, w, h, ILI9341_WHITE);
+        tft.fillRect(x0 + 1, y0 + 1, w - 2, h - 2, ILI9341_OLIVE);
+        tft.setCursor(x0 + textOffsetLeft, y0 + textOffsetTop);
+        tft.setTextColor(ILI9341_WHITE);
+        tft.setTextSize(3);
+        tft.print(buttonText);
+    }
+}
+
+void FanScreen::renderButtonPressed(Button& btn)
+{
+    if (btn.getName() == "fanUpBtn") {
+        tft.fillTriangle(240, 95, 260, 55, 280, 95, ILI9341_WHITE);
+    } else if (btn.getName() == "fanDownBtn") {
+        tft.fillTriangle(240, 110, 260, 150, 280, 110, ILI9341_WHITE);
+    }
+}
+
+void FanScreen::handleButton(Button& btn)
+{
+    if (btn.getName() == "fanAutoBtn") {
+        systemStatus.setFanAutoMode(1);
+        screenManager.renderButtons(true);
+        systemStatus.check_fan();
+
+    } else if (btn.getName() == "fanManualBtn") {
+        systemStatus.setFanAutoMode(0);
+        screenManager.renderButtons(true);
+        systemStatus.check_fan();
+
+    } else if (btn.getName() == "fanUpBtn") {
+        float fanSpeedPercent = systemStatus.getFanSpeed();
+        systemStatus.setFanAutoMode(0);
+        renderButtons(true);
+
+        if (fanSpeedPercent < 100) {
+            fanSpeedPercent += 5;
+            systemStatus.setFanSpeed(fanSpeedPercent);
+            systemStatus.check_fan();
+        }
+
+    } else if (btn.getName() == "fanDownBtn") {
+        float fanSpeedPercent = systemStatus.getFanSpeed();
+        systemStatus.setFanAutoMode(0);
+        renderButtons(true);
+
+        if (fanSpeedPercent > 0) {
+            fanSpeedPercent -= 5;
+            systemStatus.setFanSpeed(fanSpeedPercent);
+            systemStatus.check_fan();
+        }
+
+    } else if (btn.getName() == "fanOkBtn") {
+        screenManager.homeScreen();
+    }
+}

--- a/src/screens/fan.h
+++ b/src/screens/fan.h
@@ -1,0 +1,14 @@
+#ifndef FANSCREEN_H
+#define FANSCREEN_H
+
+#include "../screen.h"
+
+class FanScreen: public Screen {
+public:
+    String getName() { return "fanScreen"; }
+    void render();
+    void renderButton(Button& btn);
+    void renderButtonPressed(Button& btn);
+    void handleButton(Button &btn);
+};
+#endif

--- a/src/screens/grow_started.cpp
+++ b/src/screens/grow_started.cpp
@@ -1,0 +1,20 @@
+#include "grow_started.h"
+#include "icons.h"
+#include <Adafruit_ILI9341.h>
+
+extern Adafruit_ILI9341 tft;
+
+void GrowStartedScreen::render()
+{
+    tft.fillScreen(ILI9341_OLIVE);
+
+    tft.setTextColor(ILI9341_WHITE);
+    tft.setTextSize(3);
+
+    tft.setCursor(50, 30);
+    tft.print("Your Grow");
+    tft.setCursor(60, 90);
+    tft.print("has started!");
+
+    tft.drawBitmap(124, 160, plant_filled_72x72, 72, 72, ILI9341_WHITE);
+}

--- a/src/screens/grow_started.h
+++ b/src/screens/grow_started.h
@@ -1,0 +1,14 @@
+#ifndef GROWSTARTEDSCREEN_H
+#define GROWSTARTEDSCREEN_H
+
+#include "../screen.h"
+
+class GrowStartedScreen: public Screen {
+public:
+    String getName() { return "growStartedScreen"; }
+    void render();
+    void renderButton(Button& btn) {}
+    void renderButtonPressed(Button& btn) {}
+    void handleButton(Button &btn) {}
+};
+#endif

--- a/src/screens/home.cpp
+++ b/src/screens/home.cpp
@@ -1,0 +1,98 @@
+#include "home.h"
+#include "systemStatus.h"
+#include "icons.h"
+#include "tent.h"
+#include <Adafruit_ILI9341.h>
+
+extern Adafruit_ILI9341 tft;
+extern SystemStatus systemStatus;
+extern Tent tent;
+extern Timer minutelyTicker, draw_temp_home;
+
+void HomeScreen::render()
+{
+    tft.fillScreen(ILI9341_BLACK);
+    buttons.clear();
+    buttons.push_back(Button("wifiBtn", 260, 0, 60, 30, "", 18, 8));
+
+    if (systemStatus.getDayCount() == -1) {
+
+        tft.setTextColor(ILI9341_LIGHTGREY);
+        tft.setTextSize(2);
+
+        tft.setCursor(126, 15);
+        tft.print("Hi,");
+
+        tft.setCursor(75, 40);
+        tft.print("I'm Tomatotent.");
+
+        tft.drawBitmap(110, 65, tomato_filled_100, 100, 100, ILI9341_RED);
+
+        buttons.push_back(Button("startGrowBtn", 35, 180, 250, 38, "Start a Grow", 18, 8));
+
+    } else { // a grow is in progress
+
+        tft.drawRect(20, 180, 250, 38, ILI9341_BLACK);
+
+        systemStatus.drawDayCounter();
+
+        buttons.push_back(Button("dayCounterBtn", 20, 180, 250, 38, "", 18, 8));
+        buttons.push_back(Button("timerBtn", 10, 10, 115, 25, "", 18, 8));
+        buttons.push_back(Button("fanBtn", 145, 10, 115, 35, "", 18, 8));
+        buttons.push_back(Button("tempBtn", 50, 55, 115, 35, "", 18, 8));
+
+        tft.drawBitmap(165, 4, fan_36, 36, 36, ILI9341_WHITE);
+
+        systemStatus.drawTimerStatus();
+        systemStatus.check_fan();
+        tent.drawStats(systemStatus.getTempUnit());
+
+        if (tent.getGrowLightStatus() == "LOW") {
+            tent.drawDimmedIndicator();
+        }
+    }
+
+    renderButtons(true);
+}
+
+void HomeScreen::renderButton(Button& btn)
+{
+    if (btn.getName() == "startGrowBtn") {
+        tft.drawRect(btn.x0, btn.y0, btn.w, btn.h, ILI9341_WHITE);
+
+        tft.fillRect(btn.x0 + 1, btn.y0 + 1, btn.w - 2, btn.h - 2, ILI9341_OLIVE);
+
+        tft.setCursor(btn.x0 + btn.textOffsetLeft, btn.y0 + btn.textOffsetTop);
+        tft.setTextColor(ILI9341_WHITE);
+        tft.setTextSize(3);
+
+        tft.print(btn.buttonText);
+    }
+}
+
+void HomeScreen::renderButtonPressed(Button& btn)
+{
+    if (btn.getName() == "startGrowBtn") {
+        tft.drawRect(btn.x0, btn.y0, btn.w, btn.h, ILI9341_RED);
+    }
+}
+
+void HomeScreen::handleButton(Button& btn)
+{
+    if (btn.getName() == "startGrowBtn") {
+        tent.growLight("HIGH");
+        systemStatus.setDayCount(1);
+
+        screenManager.growStartedScreen();
+
+        delay(3000);
+
+        screenManager.homeScreen();
+
+        tent.doCheckStats(); //First time right away
+        draw_temp_home.start();
+
+        systemStatus.countMinute(); // First time on new grow
+        minutelyTicker.start();
+    }
+}

--- a/src/screens/home.cpp
+++ b/src/screens/home.cpp
@@ -57,23 +57,32 @@ void HomeScreen::render()
 
 void HomeScreen::renderButton(Button& btn)
 {
+    uint16_t x0 = btn.x0, y0 = btn.y0, w = btn.w, h = btn.h, textOffsetLeft = btn.textOffsetLeft, textOffsetTop = btn.textOffsetTop;
+    String buttonText = btn.buttonText;
+
     if (btn.getName() == "startGrowBtn") {
-        tft.drawRect(btn.x0, btn.y0, btn.w, btn.h, ILI9341_WHITE);
+        tft.drawRect(x0, y0, w, h, ILI9341_WHITE);
 
-        tft.fillRect(btn.x0 + 1, btn.y0 + 1, btn.w - 2, btn.h - 2, ILI9341_OLIVE);
+        tft.fillRect(x0 + 1, y0 + 1, w - 2, h - 2, ILI9341_OLIVE);
 
-        tft.setCursor(btn.x0 + btn.textOffsetLeft, btn.y0 + btn.textOffsetTop);
+        tft.setCursor(x0 + textOffsetLeft, y0 + textOffsetTop);
         tft.setTextColor(ILI9341_WHITE);
         tft.setTextSize(3);
 
-        tft.print(btn.buttonText);
+        tft.print(buttonText);
+
+    } else if (btn.getName() == "wifiBtn") {
+        tft.drawBitmap(289, 5, iconWifi_24x24, 24, 24, ILI9341_DARKGREY);
     }
 }
 
 void HomeScreen::renderButtonPressed(Button& btn)
 {
+    uint16_t x0 = btn.x0, y0 = btn.y0, w = btn.w, h = btn.h, textOffsetLeft = btn.textOffsetLeft, textOffsetTop = btn.textOffsetTop;
+    String buttonText = btn.buttonText;
+
     if (btn.getName() == "startGrowBtn") {
-        tft.drawRect(btn.x0, btn.y0, btn.w, btn.h, ILI9341_RED);
+        tft.drawRect(x0, y0, w, h, ILI9341_RED);
     }
 }
 
@@ -94,5 +103,20 @@ void HomeScreen::handleButton(Button& btn)
 
         systemStatus.countMinute(); // First time on new grow
         minutelyTicker.start();
+
+    } else if (btn.getName() == "wifiBtn") {
+        screenManager.wifiScreen();
+
+    } else if (btn.getName() == "dayCounterBtn") {
+        screenManager.cancelScreen();
+
+    } else if (btn.getName() == "timerBtn") {
+        screenManager.timerScreen();
+
+    } else if (btn.getName() == "fanBtn") {
+        screenManager.fanScreen();
+
+    } else if (btn.getName() == "tempBtn") {
+        screenManager.tempUnitScreen();
     }
 }

--- a/src/screens/home.h
+++ b/src/screens/home.h
@@ -1,0 +1,14 @@
+#ifndef HOMESCREEN_H
+#define HOMESCREEN_H
+
+#include "../screen.h"
+
+class HomeScreen: public Screen {
+public:
+    String getName() { return "homeScreen"; }
+    void render();
+    void renderButton(Button& btn);
+    void renderButtonPressed(Button& btn);
+    void handleButton(Button &btn);
+};
+#endif

--- a/src/screens/temp_unit.cpp
+++ b/src/screens/temp_unit.cpp
@@ -1,0 +1,79 @@
+#include "temp_unit.h"
+#include "systemStatus.h"
+#include "icons.h"
+#include "tent.h"
+#include <Adafruit_ILI9341.h>
+
+extern Adafruit_ILI9341 tft;
+extern SystemStatus systemStatus;
+extern Tent tent;
+
+void TempUnitScreen::render()
+{
+    tft.fillScreen(ILI9341_BLACK);
+
+    tft.drawBitmap(20, 4, thermometer_36, 36, 36, ILI9341_WHITE);
+
+    tft.setCursor(60, 8);
+    tft.setTextColor(ILI9341_GREEN);
+    tft.setTextSize(2);
+    tft.print("Temperature Unit");
+
+    buttons.push_back(Button("tempFahrenheitBtn", 80, 70, 150, 38, "Fahrenheit", 20, 11));
+    buttons.push_back(Button("tempCelsiusBtn", 80, 140, 150, 38, "Celsius", 40, 11));
+
+    renderButtons(true);
+}
+
+void TempUnitScreen::renderButton(Button& btn)
+{
+    uint16_t x0 = btn.x0, y0 = btn.y0, w = btn.w, h = btn.h, textOffsetLeft = btn.textOffsetLeft, textOffsetTop = btn.textOffsetTop;
+    String buttonText = btn.buttonText;
+
+    if (btn.getName() == "tempFahrenheitBtn") {
+        tft.drawRect(x0, y0, w, h, ILI9341_WHITE);
+
+        if (systemStatus.getTempUnit() == 'F') {
+            tft.fillRect(x0 + 1, y0 + 1, w - 2, h - 2, ILI9341_OLIVE);
+        } else {
+            tft.fillRect(x0 + 1, y0 + 1, w - 2, h - 2, ILI9341_BLACK);
+        }
+        tft.setCursor(x0 + textOffsetLeft, y0 + textOffsetTop);
+        tft.setTextColor(ILI9341_WHITE);
+        tft.setTextSize(2);
+        tft.print(buttonText);
+
+    } else if (btn.getName() == "tempCelsiusBtn") {
+        tft.drawRect(x0, y0, w, h, ILI9341_WHITE);
+
+        if (systemStatus.getTempUnit() == 'C') {
+            tft.fillRect(x0 + 1, y0 + 1, w - 2, h - 2, ILI9341_OLIVE);
+        } else {
+            tft.fillRect(x0 + 1, y0 + 1, w - 2, h - 2, ILI9341_BLACK);
+        }
+        tft.setCursor(x0 + textOffsetLeft, y0 + textOffsetTop);
+        tft.setTextColor(ILI9341_WHITE);
+        tft.setTextSize(2);
+        tft.print(buttonText);
+    }
+}
+
+void TempUnitScreen::renderButtonPressed(Button& btn)
+{
+}
+
+void TempUnitScreen::handleButton(Button& btn)
+{
+    if (btn.getName() == "tempFahrenheitBtn") {
+        systemStatus.setTempUnit('F');
+        screenManager.renderButtons(true);
+        screenManager.homeScreen();
+        tent.check_temperature(systemStatus.getTempUnit());
+
+    } else if (btn.getName() == "tempCelsiusBtn") {
+        systemStatus.setTempUnit('C');
+        screenManager.renderButtons(true);
+        screenManager.homeScreen();
+        tent.check_temperature(systemStatus.getTempUnit());
+    }
+}

--- a/src/screens/temp_unit.cpp
+++ b/src/screens/temp_unit.cpp
@@ -66,13 +66,13 @@ void TempUnitScreen::handleButton(Button& btn)
 {
     if (btn.getName() == "tempFahrenheitBtn") {
         systemStatus.setTempUnit('F');
-        screenManager.renderButtons(true);
+        renderButtons(true);
         screenManager.homeScreen();
         tent.check_temperature(systemStatus.getTempUnit());
 
     } else if (btn.getName() == "tempCelsiusBtn") {
         systemStatus.setTempUnit('C');
-        screenManager.renderButtons(true);
+        renderButtons(true);
         screenManager.homeScreen();
         tent.check_temperature(systemStatus.getTempUnit());
     }

--- a/src/screens/temp_unit.h
+++ b/src/screens/temp_unit.h
@@ -1,0 +1,14 @@
+#ifndef TEMPUNITSCREEN_H
+#define TEMPUNITSCREEN_H
+
+#include "../screen.h"
+
+class TempUnitScreen: public Screen {
+public:
+    String getName() { return "tempUnitScreen"; }
+    void render();
+    void renderButton(Button& btn);
+    void renderButtonPressed(Button& btn);
+    void handleButton(Button &btn);
+};
+#endif

--- a/src/screens/timer.cpp
+++ b/src/screens/timer.cpp
@@ -18,14 +18,7 @@ void TimerScreen::render()
     tft.print("Light Timer");
 
     int dayDuration = systemStatus.getDayDuration();
-
-    tft.setTextColor(ILI9341_WHITE);
-    tft.setCursor(10, 70);
-    tft.print(String(dayDuration / 60) + " Hours ON");
-
-    int nightDuration = (24 * 60) - dayDuration;
-    tft.setCursor(10, 140);
-    tft.print(String(nightDuration / 60) + " Hours OFF");
+    renderDayDuration(dayDuration);
 
     buttons.push_back(Button("timerUpBtn", 240, 50, 40, 40, "", 0, 0));
     buttons.push_back(Button("timerDownBtn", 240, 130, 40, 40, "", 0, 0));
@@ -67,49 +60,35 @@ void TimerScreen::renderButtonPressed(Button& btn)
 
 void TimerScreen::renderDayDuration(int dayDuration)
 {
+    tft.fillRect(10, 70, 200, 22, ILI9341_BLACK);
+    tft.setTextColor(ILI9341_WHITE);
+    tft.setTextSize(2);
+    tft.setCursor(10, 70);
+    tft.print(String(dayDuration / 60) + " Hours ON");
+
+    tft.setCursor(10, 140);
+    tft.fillRect(10, 140, 215, 22, ILI9341_BLACK);
+    int nightDuration = (24 * 60) - dayDuration;
+    tft.print(String(nightDuration / 60) + " Hours OFF");
 }
 
 void TimerScreen::handleButton(Button& btn)
 {
     if (btn.getName() == "timerUpBtn") {
         int dayDuration = systemStatus.getDayDuration() + 60;
-
         if (dayDuration > 1440) {
             dayDuration = 60;
         }
-
         systemStatus.setDayDuration(dayDuration);
-
-        tft.fillRect(10, 70, 200, 22, ILI9341_BLACK);
-        tft.setTextColor(ILI9341_WHITE);
-        tft.setTextSize(2);
-        tft.setCursor(10, 70);
-        tft.print(String(dayDuration / 60) + " Hours ON");
-
-        tft.setCursor(10, 140);
-        tft.fillRect(10, 140, 215, 22, ILI9341_BLACK);
-        int nightDuration = (24 * 60) - dayDuration;
-        tft.print(String(nightDuration / 60) + " Hours OFF");
+        renderDayDuration(dayDuration);
 
     } else if (btn.getName() == "timerDownBtn") {
         int dayDuration = systemStatus.getDayDuration() - 60;
-
         if (dayDuration <= 0) {
             dayDuration = 1440;
         }
-
         systemStatus.setDayDuration(dayDuration);
-
-        tft.fillRect(10, 70, 200, 22, ILI9341_BLACK);
-        tft.setTextColor(ILI9341_WHITE);
-        tft.setTextSize(2);
-        tft.setCursor(10, 70);
-        tft.print(String(dayDuration / 60) + " Hours ON");
-
-        tft.setCursor(10, 140);
-        tft.fillRect(10, 140, 215, 22, ILI9341_BLACK);
-        int nightDuration = (24 * 60) - dayDuration;
-        tft.print(String(nightDuration / 60) + " Hours OFF");
+        renderDayDuration(dayDuration);
 
     } else if (btn.getName() == "timerOkBtn") {
         screenManager.homeScreen();

--- a/src/screens/timer.cpp
+++ b/src/screens/timer.cpp
@@ -56,6 +56,11 @@ void TimerScreen::renderButton(Button& btn)
 
 void TimerScreen::renderButtonPressed(Button& btn)
 {
+    if (btn.getName() == "timerUpBtn") {
+        tft.fillTriangle(240, 95, 260, 55, 280, 95, ILI9341_WHITE);
+    } else if (btn.getName() == "timerDownBtn") {
+        tft.fillTriangle(240, 170, 260, 130, 280, 170, ILI9341_WHITE);
+    }
 }
 
 void TimerScreen::renderDayDuration(int dayDuration)

--- a/src/screens/timer.cpp
+++ b/src/screens/timer.cpp
@@ -1,0 +1,117 @@
+#include "timer.h"
+#include "systemStatus.h"
+#include "icons.h"
+#include "tent.h"
+#include <Adafruit_ILI9341.h>
+
+extern Adafruit_ILI9341 tft;
+extern SystemStatus systemStatus;
+extern Tent tent;
+
+void TimerScreen::render()
+{
+    tft.fillScreen(ILI9341_BLACK);
+
+    tft.setCursor(20, 8);
+    tft.setTextColor(ILI9341_GREEN);
+    tft.setTextSize(2);
+    tft.print("Light Timer");
+
+    int dayDuration = systemStatus.getDayDuration();
+
+    tft.setTextColor(ILI9341_WHITE);
+    tft.setCursor(10, 70);
+    tft.print(String(dayDuration / 60) + " Hours ON");
+
+    int nightDuration = (24 * 60) - dayDuration;
+    tft.setCursor(10, 140);
+    tft.print(String(nightDuration / 60) + " Hours OFF");
+
+    buttons.push_back(Button("timerUpBtn", 240, 50, 40, 40, "", 0, 0));
+    buttons.push_back(Button("timerDownBtn", 240, 130, 40, 40, "", 0, 0));
+    buttons.push_back(Button("timerOkBtn", 20, 180, 250, 38, "Ok", 110, 8));
+
+    renderButtons(true);
+
+    if (tent.getGrowLightStatus() == "LOW") {
+        tent.drawDimmedIndicator();
+    }
+}
+
+void TimerScreen::renderButton(Button& btn)
+{
+    uint16_t x0 = btn.x0, y0 = btn.y0, w = btn.w, h = btn.h, textOffsetLeft = btn.textOffsetLeft, textOffsetTop = btn.textOffsetTop;
+    String buttonText = btn.buttonText;
+
+    if (btn.getName() == "timerUpBtn") {
+        tft.fillTriangle(240, 95, 260, 55, 280, 95, ILI9341_RED);
+        tft.drawTriangle(240, 95, 260, 55, 280, 95, ILI9341_LIGHTGREY);
+
+    } else if (btn.getName() == "timerDownBtn") {
+        tft.fillTriangle(240, 170, 260, 130, 280, 170, ILI9341_RED);
+        tft.drawTriangle(240, 170, 260, 130, 280, 170, ILI9341_LIGHTGREY);
+
+    } else if (btn.getName() == "timerOkBtn") {
+        tft.drawRect(x0, y0, w, h, ILI9341_WHITE);
+        tft.fillRect(x0 + 1, y0 + 1, w - 2, h - 2, ILI9341_OLIVE);
+        tft.setCursor(x0 + textOffsetLeft, y0 + textOffsetTop);
+        tft.setTextColor(ILI9341_WHITE);
+        tft.setTextSize(3);
+        tft.print(buttonText);
+    }
+}
+
+void TimerScreen::renderButtonPressed(Button& btn)
+{
+}
+
+void TimerScreen::renderDayDuration(int dayDuration)
+{
+}
+
+void TimerScreen::handleButton(Button& btn)
+{
+    if (btn.getName() == "timerUpBtn") {
+        int dayDuration = systemStatus.getDayDuration() + 60;
+
+        if (dayDuration > 1440) {
+            dayDuration = 60;
+        }
+
+        systemStatus.setDayDuration(dayDuration);
+
+        tft.fillRect(10, 70, 200, 22, ILI9341_BLACK);
+        tft.setTextColor(ILI9341_WHITE);
+        tft.setTextSize(2);
+        tft.setCursor(10, 70);
+        tft.print(String(dayDuration / 60) + " Hours ON");
+
+        tft.setCursor(10, 140);
+        tft.fillRect(10, 140, 215, 22, ILI9341_BLACK);
+        int nightDuration = (24 * 60) - dayDuration;
+        tft.print(String(nightDuration / 60) + " Hours OFF");
+
+    } else if (btn.getName() == "timerDownBtn") {
+        int dayDuration = systemStatus.getDayDuration() - 60;
+
+        if (dayDuration <= 0) {
+            dayDuration = 1440;
+        }
+
+        systemStatus.setDayDuration(dayDuration);
+
+        tft.fillRect(10, 70, 200, 22, ILI9341_BLACK);
+        tft.setTextColor(ILI9341_WHITE);
+        tft.setTextSize(2);
+        tft.setCursor(10, 70);
+        tft.print(String(dayDuration / 60) + " Hours ON");
+
+        tft.setCursor(10, 140);
+        tft.fillRect(10, 140, 215, 22, ILI9341_BLACK);
+        int nightDuration = (24 * 60) - dayDuration;
+        tft.print(String(nightDuration / 60) + " Hours OFF");
+
+    } else if (btn.getName() == "timerOkBtn") {
+        screenManager.homeScreen();
+    }
+}

--- a/src/screens/timer.h
+++ b/src/screens/timer.h
@@ -10,5 +10,7 @@ public:
     void renderButton(Button& btn);
     void renderButtonPressed(Button& btn);
     void handleButton(Button &btn);
+private:
+    void renderDayDuration(int dayDuration);
 };
 #endif

--- a/src/screens/timer.h
+++ b/src/screens/timer.h
@@ -1,0 +1,14 @@
+#ifndef TIMERSCREEN_H
+#define TIMERSCREEN_H
+
+#include "../screen.h"
+
+class TimerScreen: public Screen {
+public:
+    String getName() { return "timerScreen"; }
+    void render();
+    void renderButton(Button& btn);
+    void renderButtonPressed(Button& btn);
+    void handleButton(Button &btn);
+};
+#endif

--- a/src/screens/wifi.cpp
+++ b/src/screens/wifi.cpp
@@ -1,0 +1,71 @@
+#include "wifi.h"
+#include "systemStatus.h"
+#include "icons.h"
+#include "tent.h"
+#include <Adafruit_ILI9341.h>
+
+extern Adafruit_ILI9341 tft;
+extern SystemStatus systemStatus;
+extern Tent tent;
+
+void WifiScreen::render()
+{
+    tft.fillScreen(ILI9341_BLACK);
+
+    buttons.push_back(Button("wifiOnBtn", 20, 40, 250, 38, "On", 110, 8));
+    buttons.push_back(Button("wifiOffBtn", 20, 100, 250, 38, "Off", 110, 8));
+    buttons.push_back(Button("wifiOkBtn", 20, 180, 250, 38, "Ok", 110, 8));
+
+    renderButtons(true);
+}
+
+void WifiScreen::renderButton(Button& btn)
+{
+    uint16_t x0 = btn.x0, y0 = btn.y0, w = btn.w, h = btn.h, textOffsetLeft = btn.textOffsetLeft, textOffsetTop = btn.textOffsetTop;
+    String buttonText = btn.buttonText;
+
+    if (btn.getName() == "wifiOnBtn") {
+        tft.drawRect(x0, y0, w, h, ILI9341_WHITE);
+        tft.fillRect(x0 + 1, y0 + 1, w - 2, h - 2, ILI9341_OLIVE);
+        tft.setCursor(x0 + textOffsetLeft, y0 + textOffsetTop);
+        tft.setTextColor(ILI9341_WHITE);
+        tft.setTextSize(3);
+        tft.print(buttonText);
+
+    } else if (btn.getName() == "wifiOffBtn") {
+        tft.drawRect(x0, y0, w, h, ILI9341_WHITE);
+        tft.fillRect(x0 + 1, y0 + 1, w - 2, h - 2, ILI9341_OLIVE);
+        tft.setCursor(x0 + textOffsetLeft, y0 + textOffsetTop);
+        tft.setTextColor(ILI9341_WHITE);
+        tft.setTextSize(3);
+        tft.print(buttonText);
+
+    } else if (btn.getName() == "wifiOkBtn") {
+        tft.drawRect(x0, y0, w, h, ILI9341_WHITE);
+        tft.fillRect(x0 + 1, y0 + 1, w - 2, h - 2, ILI9341_OLIVE);
+        tft.setCursor(x0 + textOffsetLeft, y0 + textOffsetTop);
+        tft.setTextColor(ILI9341_WHITE);
+        tft.setTextSize(3);
+        tft.print(buttonText);
+    }
+}
+
+void WifiScreen::renderButtonPressed(Button& btn)
+{
+}
+
+void WifiScreen::handleButton(Button& btn)
+{
+    if (btn.getName() == "wifiOnBtn") {
+        Particle.connect();
+        screenManager.homeScreen();
+
+    } else if (btn.getName() == "wifiOffBtn") {
+        Particle.disconnect();
+        WiFi.off();
+        screenManager.homeScreen();
+
+    } else if (btn.getName() == "wifiOkBtn") {
+        screenManager.homeScreen();
+    }
+}

--- a/src/screens/wifi.h
+++ b/src/screens/wifi.h
@@ -1,0 +1,14 @@
+#ifndef WIFISCREEN_H
+#define WIFISCREEN_H
+
+#include "../screen.h"
+
+class WifiScreen: public Screen {
+public:
+    String getName() { return "wifiScreen"; }
+    void render();
+    void renderButton(Button& btn);
+    void renderButtonPressed(Button& btn);
+    void handleButton(Button &btn);
+};
+#endif

--- a/src/screens/wifi_splash.cpp
+++ b/src/screens/wifi_splash.cpp
@@ -1,0 +1,37 @@
+#include "wifi_splash.h"
+#include "icons.h"
+#include <Adafruit_ILI9341.h>
+
+extern Adafruit_ILI9341 tft;
+
+void WifiSplashScreen::render()
+{
+    tft.fillScreen(ILI9341_BLACK);
+
+    tft.drawBitmap(18, 5, iconWifi_24x24, 24, 24, ILI9341_WHITE);
+
+    tft.setCursor(50, 10);
+    tft.setTextColor(ILI9341_GREEN);
+    tft.setTextSize(3);
+    tft.print("WiFi Setup");
+
+    tft.setTextColor(ILI9341_WHITE);
+    tft.setTextSize(1);
+    tft.setCursor(20, 50);
+    tft.print("Use a SmartPhone, Tablet or Computer");
+    tft.setCursor(20, 70);
+    tft.print("Go to WiFi settings, scan for Networks.");
+    tft.setCursor(20, 90);
+    tft.print("Connect to the Network called TomatoTent-xxxx.");
+    tft.setCursor(20, 110);
+    tft.print("Open a Web Browser (Safari, Chrome, IE).");
+    tft.setCursor(20, 130);
+    tft.print("Navigate to http://192.168.0.1");
+    tft.setCursor(20, 150);
+    tft.print("Follow the instructions there.");
+
+    tft.setCursor(20, 200);
+    tft.setTextSize(2);
+    tft.setTextColor(ILI9341_GREEN);
+    tft.print("community.tomatotent.de");
+}

--- a/src/screens/wifi_splash.h
+++ b/src/screens/wifi_splash.h
@@ -1,0 +1,14 @@
+#ifndef WIFISPLASHSCREEN_H
+#define WIFISPLASHSCREEN_H
+
+#include "../screen.h"
+
+class WifiSplashScreen: public Screen {
+public:
+    String getName() { return "WifiSplashScreen"; }
+    void render();
+    void renderButton(Button& btn) {}
+    void renderButtonPressed(Button& btn) {}
+    void handleButton(Button &btn) {}
+};
+#endif

--- a/src/systemStatus.cpp
+++ b/src/systemStatus.cpp
@@ -1,4 +1,11 @@
-#include <systemStatus.h>
+#include "systemStatus.h"
+#include "tent.h"
+#include "screen_manager.h"
+#include <Adafruit_ILI9341.h>
+
+extern Adafruit_ILI9341 tft;
+extern Tent tent;
+extern ScreenManager screenManager;
 
 SystemStatus::SystemStatus()
 {

--- a/src/systemStatus.h
+++ b/src/systemStatus.h
@@ -4,13 +4,6 @@
 #include "Particle.h"
 #include <Arduino.h>
 #include "math.h"
-#include "Adafruit_ILI9341.h"
-#include "tent.h"
-#include "screen_manager.h"
-
-extern Adafruit_ILI9341 tft;
-extern Tent tent;
-extern ScreenManager screenManager;
 
 class SystemStatus {
 

--- a/src/tent.h
+++ b/src/tent.h
@@ -4,9 +4,9 @@
 #include "Particle.h"
 #include <Arduino.h>
 #include "DFRobot_SHT20.h"
+#include "screen_manager.h"
 #include "Adafruit_ILI9341.h"
 #include "icons.h"
-#include "screen_manager.h"
 
 #define GROW_LIGHT_BRIGHTNESS_PIN TX
 #define GROW_LIGHT_ON_OFF_PIN D7


### PR DESCRIPTION
This is a big refactor of how the UI code is organized. Instead of being split across `screen_manager.cpp`, `buttons.cpp` and `Tomatotent.ino`, now there are files in `src/screens` that contain all the rendering and handling code for each screen in one place.

I'm working on testing this more thoroughly. Currently there are some bugs around pressed rendering, but all the screens render and UX navigation works as expected.