### PR TITLE
Move more drawing code into Screen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 reformat:
-	clang-format --style=WebKit --sort-includes=false -i $(shell git ls-files src/*.{cpp,h,ino} | grep -Ev '(assets|icon)')
+	clang-format --style=WebKit --sort-includes=false -i $(shell git ls-files src/*.{cpp,h,ino} src/*/*.{cpp,h} | grep -Ev '(assets|icon)')
 
 .PHONY: reformat

--- a/src/Tomatotent.ino
+++ b/src/Tomatotent.ino
@@ -229,4 +229,8 @@ void loop(void)
         systemStatus.check_fan();
         tent.resetCheckStats();
     }
+
+    if (screenManager.current) {
+        screenManager.current->update();
+    }
 }

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -2,8 +2,10 @@
 #include <Arduino.h>
 #include "screen.h"
 #include <Adafruit_ILI9341.h>
+#include "systemStatus.h"
 
 extern Adafruit_ILI9341 tft;
+extern SystemStatus systemStatus;
 
 void Screen::renderButtons(bool forced)
 {
@@ -48,4 +50,27 @@ void Screen::drawButton(Button& btn, int color, int textSize)
     tft.setTextColor(ILI9341_WHITE);
     tft.setTextSize(textSize);
     tft.print(buttonText);
+}
+
+void Screen::drawFanStatus()
+{
+    //write status to screen
+    tft.fillRect(200, 10, 56, 35, ILI9341_BLACK);
+
+    tft.setCursor(210, 10);
+    tft.setTextSize(2);
+    tft.setTextColor(ILI9341_WHITE);
+
+    tft.print(String(String::format("%.0f", systemStatus.getFanSpeed() + 5)));
+
+    tft.print("%");
+
+    tft.setTextSize(1);
+    if (systemStatus.getFanAutoMode()) {
+        tft.setCursor(200, 30);
+        tft.print("automatic");
+    } else {
+        tft.setCursor(210, 30);
+        tft.print("manual");
+    }
 }

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -1,11 +1,14 @@
 #include <Particle.h>
 #include <Arduino.h>
 #include "screen.h"
+#include "icons.h"
 #include <Adafruit_ILI9341.h>
 #include "systemStatus.h"
+#include "tent.h"
 
 extern Adafruit_ILI9341 tft;
 extern SystemStatus systemStatus;
+extern Tent tent;
 
 void Screen::renderButtons(bool forced)
 {
@@ -73,4 +76,32 @@ void Screen::drawFanStatus()
         tft.setCursor(210, 30);
         tft.print("manual");
     }
+}
+
+void Screen::update()
+{
+    if (screenManager.wasDirty(DIMMED)) {
+        if (tent.getGrowLightStatus() == "LOW") {
+            drawDimmedIndicator();
+        } else {
+            hideDimmedIndicator();
+        }
+    }
+}
+
+void Screen::drawDimmedIndicator()
+{
+    tft.fillRoundRect(0, 220, 320, 25, 5, ILI9341_RED);
+
+    tft.setCursor(120, 222);
+    tft.setTextColor(ILI9341_WHITE);
+    tft.setTextSize(2);
+    tft.print("Dimmed (" + String(tent.dimTimeout) + "m)");
+
+    tft.drawBitmap(97, 222, iconBulb_16x16, 16, 16, ILI9341_WHITE);
+}
+
+void Screen::hideDimmedIndicator()
+{
+    tft.fillRoundRect(0, 220, 320, 25, 5, ILI9341_BLACK);
 }

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -80,7 +80,7 @@ void Screen::drawFanStatus()
 
 void Screen::update()
 {
-    if (screenManager.wasDirty(DIMMED)) {
+    if (screenManager.wasNeedsRedraw(DIMMED)) {
         if (tent.getGrowLightStatus() == "LOW") {
             drawDimmedIndicator();
         } else {

--- a/src/screen.h
+++ b/src/screen.h
@@ -9,6 +9,8 @@ protected:
     std::vector<Button> buttons;
     void drawButton(Button& btn, int color, int textSize);
     void drawFanStatus();
+    void drawDimmedIndicator();
+    void hideDimmedIndicator();
 
 public:
     void renderButtons(bool forced = false);
@@ -17,7 +19,7 @@ public:
 //virtual:
     virtual String getName() = 0;
     virtual void render() = 0;
-    virtual void update() {};
+    virtual void update();
     virtual void renderButton(Button& btn) = 0;
     virtual void renderButtonPressed(Button& btn) = 0;
     virtual void handleButton(Button& btn) = 0;

--- a/src/screen.h
+++ b/src/screen.h
@@ -8,13 +8,16 @@ class Screen {
 protected:
     std::vector<Button> buttons;
     void drawButton(Button& btn, int color, int textSize);
+    void drawFanStatus();
 
 public:
     void renderButtons(bool forced = false);
     void processTouch(int x, int y);
 
+//virtual:
     virtual String getName() = 0;
     virtual void render() = 0;
+    virtual void update() {};
     virtual void renderButton(Button& btn) = 0;
     virtual void renderButtonPressed(Button& btn) = 0;
     virtual void handleButton(Button& btn) = 0;

--- a/src/screen_manager.cpp
+++ b/src/screen_manager.cpp
@@ -16,58 +16,66 @@ extern Tent tent;
 extern float fanSpeed;
 extern float fanSpeedPercent;
 
+void ScreenManager::render()
+{
+    if (current) {
+        markDirty(DIMMED);
+        current->render();
+    }
+}
+
 void ScreenManager::homeScreen()
 {
-    current = std::make_unique<HomeScreen>();
-    current->render();
+    current.reset(new HomeScreen());
+    render();
 }
 
 void ScreenManager::growStartedScreen()
 {
-    current = std::make_unique<GrowStartedScreen>();
-    current->render();
+    current.reset(new GrowStartedScreen());
+    render();
 }
 
 void ScreenManager::cancelScreen()
 {
-    current = std::make_unique<CancelScreen>();
-    current->render();
+    current.reset(new CancelScreen());
+    render();
 }
 
 void ScreenManager::cancelConfirmationScreen()
 {
-    current = std::make_unique<CancelConfirmScreen>();
-    current->render();
+    current.reset(new CancelConfirmScreen());
+    render();
 }
 
 void ScreenManager::timerScreen()
 {
-    current = std::make_unique<TimerScreen>();
-    current->render();
+    current.reset(new TimerScreen());
+    render();
 }
 
 void ScreenManager::wifiScreen()
 {
-    current = std::make_unique<WifiScreen>();
-    current->render();
+    current.reset(new WifiScreen());
+    render();
 }
 
 void ScreenManager::wifiSplashScreen()
 {
-    current = std::make_unique<WifiSplashScreen>();
-    current->render();
+    current.reset(new WifiSplashScreen());
+    render();
 }
 
 void ScreenManager::fanScreen()
 {
-    current = std::make_unique<FanScreen>();
-    current->render();
+    current.reset(new FanScreen());
+    render();
 }
 
 void ScreenManager::tempUnitScreen()
 {
-    current = std::make_unique<TempUnitScreen>();
-    current->render();
+    current.reset(new TempUnitScreen());
+    render();
 }
 
 void ScreenManager::renderButtons(bool forced)

--- a/src/screen_manager.cpp
+++ b/src/screen_manager.cpp
@@ -19,7 +19,7 @@ extern float fanSpeedPercent;
 void ScreenManager::render()
 {
     if (current) {
-        markDirty(DIMMED);
+        markNeedsRedraw(DIMMED);
         current->render();
     }
 }
@@ -85,14 +85,14 @@ void ScreenManager::renderButtons(bool forced)
     }
 }
 
-void ScreenManager::markDirty(dirtyMarker m)
+void ScreenManager::markNeedsRedraw(redrawMarker m)
 {
-    dirtyMarkers |= (int)m;
+    redrawMarkers |= (int)m;
 }
 
-bool ScreenManager::wasDirty(dirtyMarker m)
+bool ScreenManager::wasNeedsRedraw(redrawMarker m)
 {
-    bool ret = dirtyMarkers & m;
-    dirtyMarkers &= ~m;
+    bool ret = redrawMarkers & m;
+    redrawMarkers &= ~m;
     return ret;
 }

--- a/src/screen_manager.cpp
+++ b/src/screen_manager.cpp
@@ -85,3 +85,15 @@ void ScreenManager::renderButtons(bool forced)
         current->renderButtons(forced);
     }
 }
+
+void ScreenManager::markDirty(dirtyMarker m)
+{
+    dirtyMarkers |= (int)m;
+}
+
+bool ScreenManager::wasDirty(dirtyMarker m)
+{
+    bool ret = dirtyMarkers & m;
+    dirtyMarkers &= ~m;
+    return ret;
+}

--- a/src/screen_manager.cpp
+++ b/src/screen_manager.cpp
@@ -19,63 +19,54 @@ extern float fanSpeedPercent;
 void ScreenManager::homeScreen()
 {
     current = std::make_unique<HomeScreen>();
-    currentScreen = current->getName();
     current->render();
 }
 
 void ScreenManager::growStartedScreen()
 {
     current = std::make_unique<GrowStartedScreen>();
-    currentScreen = current->getName();
     current->render();
 }
 
 void ScreenManager::cancelScreen()
 {
     current = std::make_unique<CancelScreen>();
-    currentScreen = current->getName();
     current->render();
 }
 
 void ScreenManager::cancelConfirmationScreen()
 {
     current = std::make_unique<CancelConfirmScreen>();
-    currentScreen = current->getName();
     current->render();
 }
 
 void ScreenManager::timerScreen()
 {
     current = std::make_unique<TimerScreen>();
-    currentScreen = current->getName();
     current->render();
 }
 
 void ScreenManager::wifiScreen()
 {
     current = std::make_unique<WifiScreen>();
-    currentScreen = current->getName();
     current->render();
 }
 
 void ScreenManager::wifiSplashScreen()
 {
     current = std::make_unique<WifiSplashScreen>();
-    currentScreen = current->getName();
     current->render();
 }
 
 void ScreenManager::fanScreen()
 {
     current = std::make_unique<FanScreen>();
-    currentScreen = current->getName();
     current->render();
 }
 
 void ScreenManager::tempUnitScreen()
 {
     current = std::make_unique<TempUnitScreen>();
-    currentScreen = current->getName();
     current->render();
 }
 

--- a/src/screen_manager.h
+++ b/src/screen_manager.h
@@ -23,7 +23,6 @@ private:
 
 public:
     std::unique_ptr<Screen> current = std::make_unique<HomeScreen>();
-    String currentScreen = "homeScreen";
 
     ScreenManager() {};
 

--- a/src/screen_manager.h
+++ b/src/screen_manager.h
@@ -8,7 +8,7 @@
 #include "screen.h"
 #include "screens/home.h"
 
-enum dirtyMarker {
+enum redrawMarker {
     TEMPERATURE = 1,
     HUMIDITY = 2,
     WATER_LEVEL = 4,
@@ -20,7 +20,7 @@ enum dirtyMarker {
 
 class ScreenManager {
 private:
-    int dirtyMarkers;
+    int redrawMarkers;
 
     void render();
 
@@ -30,8 +30,8 @@ public:
     ScreenManager() {};
 
     void renderButtons(bool forced = false);
-    void markDirty(dirtyMarker m);
-    bool wasDirty(dirtyMarker m);
+    void markNeedsRedraw(redrawMarker m);
+    bool wasNeedsRedraw(redrawMarker m);
 
     void homeScreen();
     void growStartedScreen();

--- a/src/screen_manager.h
+++ b/src/screen_manager.h
@@ -8,7 +8,19 @@
 #include "screen.h"
 #include "screens/home.h"
 
+enum dirtyMarker {
+    TEMPERATURE = 1,
+    HUMIDITY = 2,
+    WATER_LEVEL = 4,
+    TIMER = 8,
+    FAN = 16,
+    DAY = 32
+};
+
 class ScreenManager {
+private:
+    int dirtyMarkers;
+
 public:
     std::unique_ptr<Screen> current = std::make_unique<HomeScreen>();
     String currentScreen = "homeScreen";
@@ -16,6 +28,8 @@ public:
     ScreenManager() {};
 
     void renderButtons(bool forced = false);
+    void markDirty(dirtyMarker m);
+    bool wasDirty(dirtyMarker m);
 
     void homeScreen();
     void growStartedScreen();

--- a/src/screen_manager.h
+++ b/src/screen_manager.h
@@ -14,12 +14,15 @@ enum dirtyMarker {
     WATER_LEVEL = 4,
     TIMER = 8,
     FAN = 16,
-    DAY = 32
+    DAY = 32,
+    DIMMED = 64
 };
 
 class ScreenManager {
 private:
     int dirtyMarkers;
+
+    void render();
 
 public:
     std::unique_ptr<Screen> current = std::make_unique<HomeScreen>();

--- a/src/screens/cancel.cpp
+++ b/src/screens/cancel.cpp
@@ -32,10 +32,6 @@ void CancelScreen::render()
     buttons.push_back(Button("cancelScreenOkBtn", 20, 180, 250, 38, "Ok", 110, 8));
     buttons.push_back(Button("terminateBtn", 120, 10, 185, 28, "Terminate Grow", 10, 7));
     renderButtons(true);
-
-    if (tent.getGrowLightStatus() == "LOW") {
-        tent.drawDimmedIndicator();
-    }
 }
 
 void CancelScreen::renderButton(Button& btn)

--- a/src/screens/cancel.h
+++ b/src/screens/cancel.h
@@ -3,12 +3,12 @@
 
 #include "../screen.h"
 
-class CancelScreen: public Screen {
+class CancelScreen : public Screen {
 public:
     String getName() { return "cancelScreen"; }
     void render();
     void renderButton(Button& btn);
     void renderButtonPressed(Button& btn);
-    void handleButton(Button &btn);
+    void handleButton(Button& btn);
 };
 #endif

--- a/src/screens/cancel_confirm.h
+++ b/src/screens/cancel_confirm.h
@@ -3,12 +3,12 @@
 
 #include "../screen.h"
 
-class CancelConfirmScreen: public Screen {
+class CancelConfirmScreen : public Screen {
 public:
     String getName() { return "cancelConfirmScreen"; }
     void render();
     void renderButton(Button& btn);
     void renderButtonPressed(Button& btn);
-    void handleButton(Button &btn);
+    void handleButton(Button& btn);
 };
 #endif

--- a/src/screens/fan.cpp
+++ b/src/screens/fan.cpp
@@ -31,7 +31,7 @@ void FanScreen::render()
 
 void FanScreen::update()
 {
-    if (screenManager.wasDirty(FAN))
+    if (screenManager.wasNeedsRedraw(FAN))
         drawFanStatus();
 
     Screen::update();

--- a/src/screens/fan.cpp
+++ b/src/screens/fan.cpp
@@ -26,8 +26,13 @@ void FanScreen::render()
     buttons.push_back(Button("fanOkBtn", 20, 180, 250, 38, "Ok", 110, 8));
 
     renderButtons(true);
+    drawFanStatus();
+}
 
-    systemStatus.drawFanSpeed();
+void FanScreen::update()
+{
+    if (screenManager.wasDirty(FAN))
+        drawFanStatus();
 }
 
 void FanScreen::renderButton(Button& btn)

--- a/src/screens/fan.cpp
+++ b/src/screens/fan.cpp
@@ -33,6 +33,8 @@ void FanScreen::update()
 {
     if (screenManager.wasDirty(FAN))
         drawFanStatus();
+
+    Screen::update();
 }
 
 void FanScreen::renderButton(Button& btn)

--- a/src/screens/fan.h
+++ b/src/screens/fan.h
@@ -3,13 +3,13 @@
 
 #include "../screen.h"
 
-class FanScreen: public Screen {
+class FanScreen : public Screen {
 public:
     String getName() { return "fanScreen"; }
     void render();
     void update();
     void renderButton(Button& btn);
     void renderButtonPressed(Button& btn);
-    void handleButton(Button &btn);
+    void handleButton(Button& btn);
 };
 #endif

--- a/src/screens/fan.h
+++ b/src/screens/fan.h
@@ -7,6 +7,7 @@ class FanScreen: public Screen {
 public:
     String getName() { return "fanScreen"; }
     void render();
+    void update();
     void renderButton(Button& btn);
     void renderButtonPressed(Button& btn);
     void handleButton(Button &btn);

--- a/src/screens/grow_started.h
+++ b/src/screens/grow_started.h
@@ -3,12 +3,12 @@
 
 #include "../screen.h"
 
-class GrowStartedScreen: public Screen {
+class GrowStartedScreen : public Screen {
 public:
     String getName() { return "growStartedScreen"; }
     void render();
     void renderButton(Button& btn) {}
     void renderButtonPressed(Button& btn) {}
-    void handleButton(Button &btn) {}
+    void handleButton(Button& btn) {}
 };
 #endif

--- a/src/screens/home.cpp
+++ b/src/screens/home.cpp
@@ -53,17 +53,17 @@ void HomeScreen::render()
 
 void HomeScreen::update()
 {
-    if (screenManager.wasDirty(TIMER))
+    if (screenManager.wasNeedsRedraw(TIMER))
         drawTimerStatus();
-    if (screenManager.wasDirty(TEMPERATURE))
+    if (screenManager.wasNeedsRedraw(TEMPERATURE))
         drawTemperature();
-    if (screenManager.wasDirty(HUMIDITY))
+    if (screenManager.wasNeedsRedraw(HUMIDITY))
         drawHumidity();
-    if (screenManager.wasDirty(WATER_LEVEL))
+    if (screenManager.wasNeedsRedraw(WATER_LEVEL))
         drawWaterLevel();
-    if (screenManager.wasDirty(FAN))
+    if (screenManager.wasNeedsRedraw(FAN))
         drawFanStatus();
-    if (screenManager.wasDirty(DAY))
+    if (screenManager.wasNeedsRedraw(DAY))
         drawDayCounter();
 
     Screen::update();

--- a/src/screens/home.cpp
+++ b/src/screens/home.cpp
@@ -46,10 +46,6 @@ void HomeScreen::render()
         buttons.push_back(Button("timerBtn", 10, 10, 115, 25, "", 18, 8));
         buttons.push_back(Button("fanBtn", 145, 10, 115, 35, "", 18, 8));
         buttons.push_back(Button("tempBtn", 50, 55, 115, 35, "", 18, 8));
-
-        if (tent.getGrowLightStatus() == "LOW") {
-            tent.drawDimmedIndicator();
-        }
     }
 
     renderButtons(true);
@@ -69,6 +65,8 @@ void HomeScreen::update()
         drawFanStatus();
     if (screenManager.wasDirty(DAY))
         drawDayCounter();
+
+    Screen::update();
 }
 
 void HomeScreen::drawTemperature()

--- a/src/screens/home.h
+++ b/src/screens/home.h
@@ -3,7 +3,7 @@
 
 #include "../screen.h"
 
-class HomeScreen: public Screen {
+class HomeScreen : public Screen {
 private:
     void drawTemperature();
     void drawHumidity();
@@ -11,12 +11,13 @@ private:
     void drawDayCounter();
     void drawTimerStatus();
     void drawClock();
+
 public:
     String getName() { return "homeScreen"; }
     void render();
     void update();
     void renderButton(Button& btn);
     void renderButtonPressed(Button& btn);
-    void handleButton(Button &btn);
+    void handleButton(Button& btn);
 };
 #endif

--- a/src/screens/home.h
+++ b/src/screens/home.h
@@ -4,9 +4,17 @@
 #include "../screen.h"
 
 class HomeScreen: public Screen {
+private:
+    void drawTemperature();
+    void drawHumidity();
+    void drawWaterLevel();
+    void drawDayCounter();
+    void drawTimerStatus();
+    void drawClock();
 public:
     String getName() { return "homeScreen"; }
     void render();
+    void update();
     void renderButton(Button& btn);
     void renderButtonPressed(Button& btn);
     void handleButton(Button &btn);

--- a/src/screens/temp_unit.h
+++ b/src/screens/temp_unit.h
@@ -3,12 +3,12 @@
 
 #include "../screen.h"
 
-class TempUnitScreen: public Screen {
+class TempUnitScreen : public Screen {
 public:
     String getName() { return "tempUnitScreen"; }
     void render();
     void renderButton(Button& btn);
     void renderButtonPressed(Button& btn);
-    void handleButton(Button &btn);
+    void handleButton(Button& btn);
 };
 #endif

--- a/src/screens/timer.cpp
+++ b/src/screens/timer.cpp
@@ -25,10 +25,6 @@ void TimerScreen::render()
     buttons.push_back(Button("timerOkBtn", 20, 180, 250, 38, "Ok", 110, 8));
 
     renderButtons(true);
-
-    if (tent.getGrowLightStatus() == "LOW") {
-        tent.drawDimmedIndicator();
-    }
 }
 
 void TimerScreen::renderButton(Button& btn)

--- a/src/screens/timer.h
+++ b/src/screens/timer.h
@@ -3,13 +3,14 @@
 
 #include "../screen.h"
 
-class TimerScreen: public Screen {
+class TimerScreen : public Screen {
 public:
     String getName() { return "timerScreen"; }
     void render();
     void renderButton(Button& btn);
     void renderButtonPressed(Button& btn);
-    void handleButton(Button &btn);
+    void handleButton(Button& btn);
+
 private:
     void renderDayDuration(int dayDuration);
 };

--- a/src/screens/wifi.h
+++ b/src/screens/wifi.h
@@ -3,12 +3,12 @@
 
 #include "../screen.h"
 
-class WifiScreen: public Screen {
+class WifiScreen : public Screen {
 public:
     String getName() { return "wifiScreen"; }
     void render();
     void renderButton(Button& btn);
     void renderButtonPressed(Button& btn);
-    void handleButton(Button &btn);
+    void handleButton(Button& btn);
 };
 #endif

--- a/src/screens/wifi_splash.h
+++ b/src/screens/wifi_splash.h
@@ -3,12 +3,12 @@
 
 #include "../screen.h"
 
-class WifiSplashScreen: public Screen {
+class WifiSplashScreen : public Screen {
 public:
     String getName() { return "WifiSplashScreen"; }
     void render();
     void renderButton(Button& btn) {}
     void renderButtonPressed(Button& btn) {}
-    void handleButton(Button &btn) {}
+    void handleButton(Button& btn) {}
 };
 #endif

--- a/src/systemStatus.cpp
+++ b/src/systemStatus.cpp
@@ -71,97 +71,14 @@ void SystemStatus::countMinute()
     } else {
         if (this->getMinutesInPhotoperiod() > ((24 * 60) - this->getDayDuration())) { //night is over
             this->setDayCount(this->getDayCount() + 1);
-            this->drawDayCounter();
+            screenManager.markDirty(DAY);
             tent.growLight("HIGH");
             this->setIsDay(true);
             this->setMinutesInPhotoperiod(0);
         }
     }
 
-    if (screenManager.currentScreen == "homeScreen") {
-        this->drawTimerStatus();
-    }
-}
-
-void SystemStatus::drawTimerStatus()
-{
-    int hoursLeft;
-    int minutesLeft;
-
-    if (this->isDay()) {
-        tft.setTextColor(ILI9341_YELLOW);
-        hoursLeft = floor((this->getDayDuration() - this->getMinutesInPhotoperiod()) / 60);
-        minutesLeft = (this->getDayDuration() - this->getMinutesInPhotoperiod()) % 60;
-    } else {
-        tft.setTextColor(ILI9341_BLUE);
-        hoursLeft = floor((((24 * 60) - this->getDayDuration()) - this->getMinutesInPhotoperiod()) / 60);
-        minutesLeft = (((24 * 60) - this->getDayDuration()) - this->getMinutesInPhotoperiod()) % 60;
-    }
-
-    if (hoursLeft < 0 || minutesLeft < 0) {
-
-        this->countMinute();
-
-    } else {
-
-        tft.fillRect(5, 5, 137, 37, ILI9341_BLACK);
-
-        tft.setCursor(50, 10);
-        tft.setTextSize(2);
-
-        tft.print(String(hoursLeft));
-        tft.setTextSize(1);
-        tft.print("hrs ");
-        tft.setTextSize(2);
-        tft.print("" + String(minutesLeft));
-        tft.setTextSize(1);
-        tft.print("min");
-
-        tft.setCursor(53, 31);
-        tft.setTextSize(1);
-        if (this->isDay()) {
-            tft.drawBitmap(7, 5, sun_36, 36, 36, ILI9341_YELLOW);
-            tft.print("until sunset");
-        } else {
-            tft.drawBitmap(7, 5, moon_and_stars_36, 36, 36, ILI9341_BLUE);
-            tft.print("until sunrise");
-        }
-    }
-}
-
-void SystemStatus::drawDayCounter()
-{
-    tft.fillRect(130, 180, 80, 25, ILI9341_BLACK);
-
-    tft.setCursor(70, 180);
-    tft.setTextColor(ILI9341_WHITE);
-    tft.setTextSize(3);
-
-    tft.print("Day " + String(this->getDayCount()));
-}
-
-void SystemStatus::drawFanSpeed()
-{
-    //write status to screen
-    tft.fillRect(200, 10, 56, 35, ILI9341_BLACK);
-
-    tft.setCursor(210, 10);
-    tft.setTextSize(2);
-    tft.setTextColor(ILI9341_WHITE);
-
-    //tft.print(String(String::format("%.0f",this->status.fanSpeed)));
-    tft.print(String(String::format("%.0f", this->status.fanSpeed + 5)));
-
-    tft.print("%");
-
-    tft.setTextSize(1);
-    if (this->status.fanAutoMode) {
-        tft.setCursor(200, 30);
-        tft.print("automatic");
-    } else {
-        tft.setCursor(210, 30);
-        tft.print("manual");
-    }
+    screenManager.markDirty(TIMER);
 }
 
 bool SystemStatus::getFanAutoMode()
@@ -243,9 +160,7 @@ void SystemStatus::check_fan()
         analogWrite(FAN_SPEED_PIN, 255 - fanSpeed, 25000);
     }
 
-    if (screenManager.currentScreen == "homeScreen" || screenManager.currentScreen == "fanScreen") {
-        this->drawFanSpeed();
-    }
+    screenManager.markDirty(FAN);
 }
 
 void SystemStatus::init()

--- a/src/systemStatus.cpp
+++ b/src/systemStatus.cpp
@@ -71,14 +71,14 @@ void SystemStatus::countMinute()
     } else {
         if (this->getMinutesInPhotoperiod() > ((24 * 60) - this->getDayDuration())) { //night is over
             this->setDayCount(this->getDayCount() + 1);
-            screenManager.markDirty(DAY);
+            screenManager.markNeedsRedraw(DAY);
             tent.growLight("HIGH");
             this->setIsDay(true);
             this->setMinutesInPhotoperiod(0);
         }
     }
 
-    screenManager.markDirty(TIMER);
+    screenManager.markNeedsRedraw(TIMER);
 }
 
 bool SystemStatus::getFanAutoMode()
@@ -160,7 +160,7 @@ void SystemStatus::check_fan()
         analogWrite(FAN_SPEED_PIN, 255 - fanSpeed, 25000);
     }
 
-    screenManager.markDirty(FAN);
+    screenManager.markNeedsRedraw(FAN);
 }
 
 void SystemStatus::init()

--- a/src/systemStatus.h
+++ b/src/systemStatus.h
@@ -39,9 +39,6 @@ public:
     void setFanSpeed(float);
     void setTempUnit(char);
     void countMinute();
-    void drawTimerStatus();
-    void drawFanSpeed();
-    void drawDayCounter();
     void init();
     void save();
 };

--- a/src/tent.cpp
+++ b/src/tent.cpp
@@ -23,7 +23,7 @@ void Tent::check_temperature(char tempUnit)
 
     if ((temp == 0) || (temp != currentTemp)) {
         temp = currentTemp;
-        screenManager.markDirty(TEMPERATURE);
+        screenManager.markNeedsRedraw(TEMPERATURE);
     }
 }
 
@@ -33,7 +33,7 @@ void Tent::check_humidity()
 
     if ((hum == 0) || (hum != currentHumidity)) {
         hum = currentHumidity;
-        screenManager.markDirty(HUMIDITY);
+        screenManager.markNeedsRedraw(HUMIDITY);
     }
 }
 
@@ -43,7 +43,7 @@ void Tent::check_waterlevel()
 
     if ((waterLevel == 0) || (waterLevel != currentWaterLevel)) {
         waterLevel = currentWaterLevel;
-        screenManager.markDirty(WATER_LEVEL);
+        screenManager.markNeedsRedraw(WATER_LEVEL);
     }
 }
 
@@ -102,7 +102,7 @@ void Tent::minutelyTick()
         if (this->dimTimeout == 0) {
             this->growLight("HIGH");
         }
-        screenManager.markDirty(DIMMED);
+        screenManager.markNeedsRedraw(DIMMED);
     }
 }
 
@@ -116,7 +116,7 @@ void Tent::dimGrowLight()
         this->growLight("HIGH");
     }
 
-    screenManager.markDirty(DIMMED);
+    screenManager.markNeedsRedraw(DIMMED);
 }
 
 void Tent::displayLightLow(void)

--- a/src/tent.cpp
+++ b/src/tent.cpp
@@ -101,10 +101,8 @@ void Tent::minutelyTick()
         this->dimTimeout -= 1;
         if (this->dimTimeout == 0) {
             this->growLight("HIGH");
-            tft.fillRoundRect(0, 220, 320, 25, 5, ILI9341_BLACK);
-        } else {
-            this->drawDimmedIndicator();
         }
+        screenManager.markDirty(DIMMED);
     }
 }
 
@@ -113,27 +111,12 @@ void Tent::dimGrowLight()
     this->displayLightHigh();
 
     if (this->growLightStatus == "HIGH") {
-
         this->growLight("LOW");
-        this->drawDimmedIndicator();
-
     } else if (this->growLightStatus == "LOW") {
-
         this->growLight("HIGH");
-        tft.fillRoundRect(0, 220, 320, 25, 5, ILI9341_BLACK);
     }
-}
 
-void Tent::drawDimmedIndicator()
-{
-    tft.fillRoundRect(0, 220, 320, 25, 5, ILI9341_RED);
-
-    tft.setCursor(120, 222);
-    tft.setTextColor(ILI9341_WHITE);
-    tft.setTextSize(2);
-    tft.print("Dimmed (" + String(dimTimeout) + "m)");
-
-    tft.drawBitmap(97, 222, iconBulb_16x16, 16, 16, ILI9341_WHITE);
+    screenManager.markDirty(DIMMED);
 }
 
 void Tent::displayLightLow(void)

--- a/src/tent.cpp
+++ b/src/tent.cpp
@@ -23,30 +23,7 @@ void Tent::check_temperature(char tempUnit)
 
     if ((temp == 0) || (temp != currentTemp)) {
         temp = currentTemp;
-        this->draw_temperature_home(tempUnit);
-    }
-}
-
-void Tent::draw_temperature_home(char tempUnit)
-{
-    if (screenManager.currentScreen == "homeScreen") {
-
-        //reset screen
-        tft.fillRect(50, 60, 141, 25, ILI9341_BLACK);
-
-        //Temperature
-        tft.setCursor(50, 60);
-        tft.setTextColor(ILI9341_GREEN);
-        tft.setTextSize(3);
-
-        tft.print(String::format("%.1f", temp));
-        tft.setTextSize(2);
-
-        if (tempUnit == 'F') {
-            tft.print(" F");
-        } else {
-            tft.print(" C");
-        }
+        screenManager.markDirty(TEMPERATURE);
     }
 }
 
@@ -56,24 +33,7 @@ void Tent::check_humidity()
 
     if ((hum == 0) || (hum != currentHumidity)) {
         hum = currentHumidity;
-        this->draw_humidity_home();
-    }
-}
-
-void Tent::draw_humidity_home()
-{
-    if (screenManager.currentScreen == "homeScreen") {
-        /////// Humidity
-        tft.fillRect(50, 110, 141, 25, ILI9341_BLACK);
-
-        tft.setCursor(50, 110);
-        tft.setTextColor(ILI9341_PINK);
-        tft.setTextSize(3);
-
-        tft.print(String::format("%.1f", hum));
-
-        tft.setTextSize(2);
-        tft.print(" %");
+        screenManager.markDirty(HUMIDITY);
     }
 }
 
@@ -83,31 +43,7 @@ void Tent::check_waterlevel()
 
     if ((waterLevel == 0) || (waterLevel != currentWaterLevel)) {
         waterLevel = currentWaterLevel;
-        this->draw_waterlevel_home();
-    }
-}
-
-void Tent::draw_waterlevel_home()
-{
-    if (screenManager.currentScreen == "homeScreen") {
-        const float waterLevelBoxHeight = 150;
-        const int waterLevelBoxTop = 60;
-
-        int waterLevelHeight = floor((waterLevelBoxHeight / 100) * waterLevel);
-
-        int waterLevelTop = (waterLevelBoxHeight - waterLevelHeight) + waterLevelBoxTop - 1;
-
-        //icon
-        tft.drawBitmap(280, 30, iconWateringCan_24x24, 24, 24, ILI9341_GREEN);
-
-        //outside box
-        tft.drawRect(280, waterLevelBoxTop, 25, waterLevelBoxHeight, ILI9341_DARKGREY);
-
-        //reset the box
-        tft.fillRect(281, waterLevelBoxTop + 1, 23, waterLevelBoxHeight - 2, ILI9341_BLACK);
-
-        //draw current water level
-        tft.fillRect(281, waterLevelTop, 23, waterLevelHeight, ILI9341_BLUE);
+        screenManager.markDirty(WATER_LEVEL);
     }
 }
 
@@ -131,13 +67,6 @@ bool Tent::getCheckStats()
 void Tent::resetCheckStats()
 {
     this->checkStats = false;
-}
-
-void Tent::drawStats(char tempUnit)
-{ //only draws stats
-    this->draw_temperature_home(tempUnit);
-    this->draw_humidity_home();
-    this->draw_waterlevel_home(); //remove for stand alone controller
 }
 
 int Tent::growLight(String brightness)
@@ -246,17 +175,3 @@ bool Tent::displayLightHigh()
         return false;
     }
 }
-
-/* 
-void Tent::drawTime() {
-    String currentTime = Time.format(Time.now(), "%l:%M %P %S");
-
-    tft.fillRect(190,7,140,18,ILI9341_BLACK);
-
-    tft.setCursor(190, 7);
-    tft.setTextColor(ILI9341_WHITE);
-    tft.setTextSize(2);
-
-    tft.print(currentTime);
-}
-*/

--- a/src/tent.h
+++ b/src/tent.h
@@ -25,12 +25,12 @@ extern ScreenManager screenManager;
 class Tent {
 
     int displayBrightness = 0;
-    int dimTimeout = 0;
     String growLightStatus;
 
 public:
     Tent();
     unsigned long lastTime = 0;
+    int dimTimeout = 0;
     Timer* tp;
     Timer* tp1;
     bool checkStats;
@@ -47,7 +47,6 @@ public:
     int growLight(String brightness);
     String getGrowLightStatus();
     void dimGrowLight();
-    void drawDimmedIndicator();
     void displayLightLow(void);
     void displayLightOff(void);
     bool displayLightHigh(void);

--- a/src/tent.h
+++ b/src/tent.h
@@ -37,17 +37,13 @@ public:
 
     void begin();
     void check_temperature(char tempUnit);
-    void draw_temperature_home(char tempUnit);
     void check_humidity();
-    void draw_humidity_home();
     void check_waterlevel();
-    void draw_waterlevel_home();
     void fan(String fanStatus);
     void doCheckStats();
     bool getCheckStats();
     void resetCheckStats();
     void minutelyTick();
-    void drawStats(char tempUnit);
     int growLight(String brightness);
     String getGrowLightStatus();
     void dimGrowLight();
@@ -55,7 +51,5 @@ public:
     void displayLightLow(void);
     void displayLightOff(void);
     bool displayLightHigh(void);
-
-    // void drawTime();
 };
 #endif


### PR DESCRIPTION
I think this will also fix the display corruption bug. Instead of writing to the screen from the timers, now we signal the ScreenManager using (for example) `screenManager.markDirty(FAN)`, and each Screen can implement a new `update()` method to redraw anything that has changed.