### PR TITLE
Move dimmed indicator into Screen

### DIFF
--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -1,11 +1,14 @@
 #include <Particle.h>
 #include <Arduino.h>
 #include "screen.h"
+#include "icons.h"
 #include <Adafruit_ILI9341.h>
 #include "systemStatus.h"
+#include "tent.h"
 
 extern Adafruit_ILI9341 tft;
 extern SystemStatus systemStatus;
+extern Tent tent;
 
 void Screen::renderButtons(bool forced)
 {
@@ -73,4 +76,32 @@ void Screen::drawFanStatus()
         tft.setCursor(210, 30);
         tft.print("manual");
     }
+}
+
+void Screen::update()
+{
+    if (screenManager.wasDirty(DIMMED)) {
+        if (tent.getGrowLightStatus() == "LOW") {
+            drawDimmedIndicator();
+        } else {
+            hideDimmedIndicator();
+        }
+    }
+}
+
+void Screen::drawDimmedIndicator()
+{
+    tft.fillRoundRect(0, 220, 320, 25, 5, ILI9341_RED);
+
+    tft.setCursor(120, 222);
+    tft.setTextColor(ILI9341_WHITE);
+    tft.setTextSize(2);
+    tft.print("Dimmed (" + String(tent.dimTimeout) + "m)");
+
+    tft.drawBitmap(97, 222, iconBulb_16x16, 16, 16, ILI9341_WHITE);
+}
+
+void Screen::hideDimmedIndicator()
+{
+    tft.fillRoundRect(0, 220, 320, 25, 5, ILI9341_BLACK);
 }

--- a/src/screen.h
+++ b/src/screen.h
@@ -9,6 +9,8 @@ protected:
     std::vector<Button> buttons;
     void drawButton(Button& btn, int color, int textSize);
     void drawFanStatus();
+    void drawDimmedIndicator();
+    void hideDimmedIndicator();
 
 public:
     void renderButtons(bool forced = false);
@@ -17,7 +19,7 @@ public:
 //virtual:
     virtual String getName() = 0;
     virtual void render() = 0;
-    virtual void update() {};
+    virtual void update();
     virtual void renderButton(Button& btn) = 0;
     virtual void renderButtonPressed(Button& btn) = 0;
     virtual void handleButton(Button& btn) = 0;

--- a/src/screen_manager.cpp
+++ b/src/screen_manager.cpp
@@ -16,58 +16,66 @@ extern Tent tent;
 extern float fanSpeed;
 extern float fanSpeedPercent;
 
+void ScreenManager::render()
+{
+    if (current) {
+        markDirty(DIMMED);
+        current->render();
+    }
+}
+
 void ScreenManager::homeScreen()
 {
-    current = std::make_unique<HomeScreen>();
-    current->render();
+    current.reset(new HomeScreen());
+    render();
 }
 
 void ScreenManager::growStartedScreen()
 {
-    current = std::make_unique<GrowStartedScreen>();
-    current->render();
+    current.reset(new GrowStartedScreen());
+    render();
 }
 
 void ScreenManager::cancelScreen()
 {
-    current = std::make_unique<CancelScreen>();
-    current->render();
+    current.reset(new CancelScreen());
+    render();
 }
 
 void ScreenManager::cancelConfirmationScreen()
 {
-    current = std::make_unique<CancelConfirmScreen>();
-    current->render();
+    current.reset(new CancelConfirmScreen());
+    render();
 }
 
 void ScreenManager::timerScreen()
 {
-    current = std::make_unique<TimerScreen>();
-    current->render();
+    current.reset(new TimerScreen());
+    render();
 }
 
 void ScreenManager::wifiScreen()
 {
-    current = std::make_unique<WifiScreen>();
-    current->render();
+    current.reset(new WifiScreen());
+    render();
 }
 
 void ScreenManager::wifiSplashScreen()
 {
-    current = std::make_unique<WifiSplashScreen>();
-    current->render();
+    current.reset(new WifiSplashScreen());
+    render();
 }
 
 void ScreenManager::fanScreen()
 {
-    current = std::make_unique<FanScreen>();
-    current->render();
+    current.reset(new FanScreen());
+    render();
 }
 
 void ScreenManager::tempUnitScreen()
 {
-    current = std::make_unique<TempUnitScreen>();
-    current->render();
+    current.reset(new TempUnitScreen());
+    render();
 }
 
 void ScreenManager::renderButtons(bool forced)

--- a/src/screen_manager.h
+++ b/src/screen_manager.h
@@ -14,12 +14,15 @@ enum dirtyMarker {
     WATER_LEVEL = 4,
     TIMER = 8,
     FAN = 16,
-    DAY = 32
+    DAY = 32,
+    DIMMED = 64
 };
 
 class ScreenManager {
 private:
     int dirtyMarkers;
+
+    void render();
 
 public:
     std::unique_ptr<Screen> current = std::make_unique<HomeScreen>();

--- a/src/screens/cancel.cpp
+++ b/src/screens/cancel.cpp
@@ -32,10 +32,6 @@ void CancelScreen::render()
     buttons.push_back(Button("cancelScreenOkBtn", 20, 180, 250, 38, "Ok", 110, 8));
     buttons.push_back(Button("terminateBtn", 120, 10, 185, 28, "Terminate Grow", 10, 7));
     renderButtons(true);
-
-    if (tent.getGrowLightStatus() == "LOW") {
-        tent.drawDimmedIndicator();
-    }
 }
 
 void CancelScreen::renderButton(Button& btn)

--- a/src/screens/fan.cpp
+++ b/src/screens/fan.cpp
@@ -33,6 +33,8 @@ void FanScreen::update()
 {
     if (screenManager.wasDirty(FAN))
         drawFanStatus();
+
+    Screen::update();
 }
 
 void FanScreen::renderButton(Button& btn)

--- a/src/screens/home.cpp
+++ b/src/screens/home.cpp
@@ -46,10 +46,6 @@ void HomeScreen::render()
         buttons.push_back(Button("timerBtn", 10, 10, 115, 25, "", 18, 8));
         buttons.push_back(Button("fanBtn", 145, 10, 115, 35, "", 18, 8));
         buttons.push_back(Button("tempBtn", 50, 55, 115, 35, "", 18, 8));
-
-        if (tent.getGrowLightStatus() == "LOW") {
-            tent.drawDimmedIndicator();
-        }
     }
 
     renderButtons(true);
@@ -69,6 +65,8 @@ void HomeScreen::update()
         drawFanStatus();
     if (screenManager.wasDirty(DAY))
         drawDayCounter();
+
+    Screen::update();
 }
 
 void HomeScreen::drawTemperature()

--- a/src/screens/timer.cpp
+++ b/src/screens/timer.cpp
@@ -25,10 +25,6 @@ void TimerScreen::render()
     buttons.push_back(Button("timerOkBtn", 20, 180, 250, 38, "Ok", 110, 8));
 
     renderButtons(true);
-
-    if (tent.getGrowLightStatus() == "LOW") {
-        tent.drawDimmedIndicator();
-    }
 }
 
 void TimerScreen::renderButton(Button& btn)

--- a/src/tent.cpp
+++ b/src/tent.cpp
@@ -101,10 +101,8 @@ void Tent::minutelyTick()
         this->dimTimeout -= 1;
         if (this->dimTimeout == 0) {
             this->growLight("HIGH");
-            tft.fillRoundRect(0, 220, 320, 25, 5, ILI9341_BLACK);
-        } else {
-            this->drawDimmedIndicator();
         }
+        screenManager.markDirty(DIMMED);
     }
 }
 
@@ -113,27 +111,12 @@ void Tent::dimGrowLight()
     this->displayLightHigh();
 
     if (this->growLightStatus == "HIGH") {
-
         this->growLight("LOW");
-        this->drawDimmedIndicator();
-
     } else if (this->growLightStatus == "LOW") {
-
         this->growLight("HIGH");
-        tft.fillRoundRect(0, 220, 320, 25, 5, ILI9341_BLACK);
     }
-}
 
-void Tent::drawDimmedIndicator()
-{
-    tft.fillRoundRect(0, 220, 320, 25, 5, ILI9341_RED);
-
-    tft.setCursor(120, 222);
-    tft.setTextColor(ILI9341_WHITE);
-    tft.setTextSize(2);
-    tft.print("Dimmed (" + String(dimTimeout) + "m)");
-
-    tft.drawBitmap(97, 222, iconBulb_16x16, 16, 16, ILI9341_WHITE);
+    screenManager.markDirty(DIMMED);
 }
 
 void Tent::displayLightLow(void)

--- a/src/tent.h
+++ b/src/tent.h
@@ -25,12 +25,12 @@ extern ScreenManager screenManager;
 class Tent {
 
     int displayBrightness = 0;
-    int dimTimeout = 0;
     String growLightStatus;
 
 public:
     Tent();
     unsigned long lastTime = 0;
+    int dimTimeout = 0;
     Timer* tp;
     Timer* tp1;
     bool checkStats;
@@ -47,7 +47,6 @@ public:
     int growLight(String brightness);
     String getGrowLightStatus();
     void dimGrowLight();
-    void drawDimmedIndicator();
     void displayLightLow(void);
     void displayLightOff(void);
     bool displayLightHigh(void);


### PR DESCRIPTION
This is a follow-on to #10 

The dimmed indicator is implemented in the `Screen::update` base implementation now, so while dimmed this notification will appear on all other screens.

This means now there is one place I can add other global UI like a notification when the led has been turned off using double-click.