### PR TITLE
Move touchscreen globals into ScreenManager

### DIFF
--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -2,13 +2,17 @@
 #include <Arduino.h>
 #include "screen.h"
 #include "icons.h"
-#include <Adafruit_ILI9341.h>
 #include "systemStatus.h"
 #include "tent.h"
+#include "screen_manager.h"
 
-extern Adafruit_ILI9341 tft;
+extern ScreenManager screenManager;
 extern SystemStatus systemStatus;
 extern Tent tent;
+
+Screen::Screen(): tft { screenManager.tft }
+{
+}
 
 void Screen::renderButtons(bool forced)
 {

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -10,7 +10,8 @@ extern ScreenManager screenManager;
 extern SystemStatus systemStatus;
 extern Tent tent;
 
-Screen::Screen(): tft { screenManager.tft }
+Screen::Screen()
+    : tft { screenManager.tft }
 {
 }
 

--- a/src/screen.h
+++ b/src/screen.h
@@ -3,9 +3,11 @@
 
 #include <vector>
 #include "button.h"
+#include "Adafruit_ILI9341.h"
 
 class Screen {
 protected:
+    Adafruit_ILI9341& tft;
     std::vector<Button> buttons;
     void drawButton(Button& btn, int color, int textSize);
     void drawFanStatus();
@@ -13,6 +15,7 @@ protected:
     void hideDimmedIndicator();
 
 public:
+    Screen();
     void renderButtons(bool forced = false);
     void processTouch(int x, int y);
 

--- a/src/screen_manager.cpp
+++ b/src/screen_manager.cpp
@@ -49,6 +49,7 @@ void ScreenManager::render()
     if (current) {
         markNeedsRedraw(DIMMED);
         current->render();
+        current->update();
     }
 }
 

--- a/src/screen_manager.cpp
+++ b/src/screen_manager.cpp
@@ -10,11 +10,39 @@
 #include "screens/wifi_splash.h"
 #include "screens/wifi.h"
 
-extern Adafruit_ILI9341 tft;
 extern SystemStatus systemStatus;
 extern Tent tent;
 extern float fanSpeed;
 extern float fanSpeedPercent;
+
+void ScreenManager::setup()
+{
+    tft.begin();
+    tft.setRotation(1);
+    tft.fillScreen(ILI9341_BLACK);
+
+    ts.begin();
+    ts.setRotation(3); // 1 for 2.4 screen, 3 for 2.8
+}
+
+void ScreenManager::tick()
+{
+    if (ts.touched()) {
+        tent.displayLightHigh(); // Switch on Displaylight on touch
+
+        if (!screenManager.current) {
+            return;
+        }
+
+        TS_Point p = ts.getPosition();
+        p.x += 20; // calibration
+        screenManager.current->processTouch(p.x, p.y);
+        delay(10);
+
+    } else {
+        screenManager.renderButtons();
+    }
+}
 
 void ScreenManager::render()
 {

--- a/src/screen_manager.h
+++ b/src/screen_manager.h
@@ -8,6 +8,15 @@
 #include "screen.h"
 #include "screens/home.h"
 
+#include "XPT2046_Touch.h"
+#include "Adafruit_ILI9341.h"
+#include "Adafruit_mfGFX.h"
+
+#define CS_PIN D5
+#define TIRQ_PIN A0
+#define TFT_DC A1
+#define TFT_CS A2
+
 enum redrawMarker {
     TEMPERATURE = 1,
     HUMIDITY = 2,
@@ -21,13 +30,16 @@ enum redrawMarker {
 class ScreenManager {
 private:
     int redrawMarkers;
-
     void render();
 
+    XPT2046_Touchscreen ts = XPT2046_Touchscreen(SPI1, 320, 240, CS_PIN, TIRQ_PIN);
+
 public:
+    Adafruit_ILI9341 tft = Adafruit_ILI9341(TFT_CS, TFT_DC, D6);
     std::unique_ptr<Screen> current = std::make_unique<HomeScreen>();
 
-    ScreenManager() {};
+    void setup();
+    void tick();
 
     void renderButtons(bool forced = false);
     void markNeedsRedraw(redrawMarker m);

--- a/src/screens/cancel.cpp
+++ b/src/screens/cancel.cpp
@@ -4,7 +4,6 @@
 #include "tent.h"
 #include <Adafruit_ILI9341.h>
 
-extern Adafruit_ILI9341 tft;
 extern SystemStatus systemStatus;
 extern Tent tent;
 

--- a/src/screens/cancel.cpp
+++ b/src/screens/cancel.cpp
@@ -2,7 +2,6 @@
 #include "systemStatus.h"
 #include "icons.h"
 #include "tent.h"
-#include <Adafruit_ILI9341.h>
 
 extern SystemStatus systemStatus;
 extern Tent tent;

--- a/src/screens/cancel_confirm.cpp
+++ b/src/screens/cancel_confirm.cpp
@@ -4,7 +4,6 @@
 #include "tent.h"
 #include <Adafruit_ILI9341.h>
 
-extern Adafruit_ILI9341 tft;
 extern SystemStatus systemStatus;
 extern Tent tent;
 extern Timer minutelyTicker, draw_temp_home;

--- a/src/screens/cancel_confirm.cpp
+++ b/src/screens/cancel_confirm.cpp
@@ -2,7 +2,6 @@
 #include "systemStatus.h"
 #include "icons.h"
 #include "tent.h"
-#include <Adafruit_ILI9341.h>
 
 extern SystemStatus systemStatus;
 extern Tent tent;

--- a/src/screens/fan.cpp
+++ b/src/screens/fan.cpp
@@ -4,7 +4,6 @@
 #include "tent.h"
 #include <Adafruit_ILI9341.h>
 
-extern Adafruit_ILI9341 tft;
 extern SystemStatus systemStatus;
 extern Tent tent;
 

--- a/src/screens/fan.cpp
+++ b/src/screens/fan.cpp
@@ -2,7 +2,6 @@
 #include "systemStatus.h"
 #include "icons.h"
 #include "tent.h"
-#include <Adafruit_ILI9341.h>
 
 extern SystemStatus systemStatus;
 extern Tent tent;

--- a/src/screens/grow_started.cpp
+++ b/src/screens/grow_started.cpp
@@ -2,8 +2,6 @@
 #include "icons.h"
 #include <Adafruit_ILI9341.h>
 
-extern Adafruit_ILI9341 tft;
-
 void GrowStartedScreen::render()
 {
     tft.fillScreen(ILI9341_OLIVE);

--- a/src/screens/grow_started.cpp
+++ b/src/screens/grow_started.cpp
@@ -1,6 +1,5 @@
 #include "grow_started.h"
 #include "icons.h"
-#include <Adafruit_ILI9341.h>
 
 void GrowStartedScreen::render()
 {

--- a/src/screens/home.cpp
+++ b/src/screens/home.cpp
@@ -4,7 +4,6 @@
 #include "tent.h"
 #include <Adafruit_ILI9341.h>
 
-extern Adafruit_ILI9341 tft;
 extern SystemStatus systemStatus;
 extern Tent tent;
 extern Timer minutelyTicker, draw_temp_home;

--- a/src/screens/home.cpp
+++ b/src/screens/home.cpp
@@ -2,7 +2,6 @@
 #include "systemStatus.h"
 #include "icons.h"
 #include "tent.h"
-#include <Adafruit_ILI9341.h>
 
 extern SystemStatus systemStatus;
 extern Tent tent;

--- a/src/screens/temp_unit.cpp
+++ b/src/screens/temp_unit.cpp
@@ -4,7 +4,6 @@
 #include "tent.h"
 #include <Adafruit_ILI9341.h>
 
-extern Adafruit_ILI9341 tft;
 extern SystemStatus systemStatus;
 extern Tent tent;
 

--- a/src/screens/temp_unit.cpp
+++ b/src/screens/temp_unit.cpp
@@ -2,7 +2,6 @@
 #include "systemStatus.h"
 #include "icons.h"
 #include "tent.h"
-#include <Adafruit_ILI9341.h>
 
 extern SystemStatus systemStatus;
 extern Tent tent;

--- a/src/screens/timer.cpp
+++ b/src/screens/timer.cpp
@@ -4,7 +4,6 @@
 #include "tent.h"
 #include <Adafruit_ILI9341.h>
 
-extern Adafruit_ILI9341 tft;
 extern SystemStatus systemStatus;
 extern Tent tent;
 

--- a/src/screens/timer.cpp
+++ b/src/screens/timer.cpp
@@ -2,7 +2,6 @@
 #include "systemStatus.h"
 #include "icons.h"
 #include "tent.h"
-#include <Adafruit_ILI9341.h>
 
 extern SystemStatus systemStatus;
 extern Tent tent;

--- a/src/screens/wifi.cpp
+++ b/src/screens/wifi.cpp
@@ -4,7 +4,6 @@
 #include "tent.h"
 #include <Adafruit_ILI9341.h>
 
-extern Adafruit_ILI9341 tft;
 extern SystemStatus systemStatus;
 extern Tent tent;
 

--- a/src/screens/wifi.cpp
+++ b/src/screens/wifi.cpp
@@ -2,7 +2,6 @@
 #include "systemStatus.h"
 #include "icons.h"
 #include "tent.h"
-#include <Adafruit_ILI9341.h>
 
 extern SystemStatus systemStatus;
 extern Tent tent;

--- a/src/screens/wifi_splash.cpp
+++ b/src/screens/wifi_splash.cpp
@@ -1,6 +1,5 @@
 #include "wifi_splash.h"
 #include "icons.h"
-#include <Adafruit_ILI9341.h>
 
 void WifiSplashScreen::render()
 {

--- a/src/screens/wifi_splash.cpp
+++ b/src/screens/wifi_splash.cpp
@@ -2,8 +2,6 @@
 #include "icons.h"
 #include <Adafruit_ILI9341.h>
 
-extern Adafruit_ILI9341 tft;
-
 void WifiSplashScreen::render()
 {
     tft.fillScreen(ILI9341_BLACK);

--- a/src/systemStatus.cpp
+++ b/src/systemStatus.cpp
@@ -3,7 +3,6 @@
 #include "screen_manager.h"
 #include <Adafruit_ILI9341.h>
 
-extern Adafruit_ILI9341 tft;
 extern Tent tent;
 extern ScreenManager screenManager;
 

--- a/src/tent.h
+++ b/src/tent.h
@@ -5,7 +5,6 @@
 #include <Arduino.h>
 #include "DFRobot_SHT20.h"
 #include "screen_manager.h"
-#include "Adafruit_ILI9341.h"
 #include "icons.h"
 
 #define GROW_LIGHT_BRIGHTNESS_PIN TX
@@ -16,7 +15,6 @@
 #define DIM_PIN DAC
 
 extern DFRobot_SHT20 sht20;
-extern Adafruit_ILI9341 tft;
 extern double temp;
 extern double hum;
 extern double waterLevel;


### PR DESCRIPTION
I'm trying to reduce the number of global variables. Now the tft/ts objects are owned by the ScreenManager and made available to all Screen subclasses to use.