### PR TITLE
Remove global variables used for sensors

### DIFF
--- a/src/Tomatotent.ino
+++ b/src/Tomatotent.ino
@@ -9,9 +9,6 @@
 PRODUCT_ID(10167);
 PRODUCT_VERSION(9);
 
-double temp;
-double hum;
-double waterLevel;
 unsigned long dimmerBtnTime = 0;
 
 DFRobot_SHT20 sht20;
@@ -129,13 +126,6 @@ void setup()
     sht20.initSHT20();
     delay(255);
     sht20.checkSHT20();
-
-    //REMOTE FUNCTIONS
-    Particle.variable("temperature", temp);
-    Particle.variable("humidity", hum);
-    //Particle.variable("fanSpeed", fanSpeed);
-
-    //END REMOTE FUNCTIONS
 
     screenManager.homeScreen();
     tent.begin();

--- a/src/Tomatotent.ino
+++ b/src/Tomatotent.ino
@@ -20,7 +20,7 @@ Tent tent;
 ScreenManager screenManager;
 
 Timer draw_temp_home(7013, &Tent::doCheckStats, tent);
-Timer minutelyTicker(60000, &minutelyTick);
+Timer minutelyTicker(60000, &Tent::minutelyTick, tent);
 
 SYSTEM_MODE(SEMI_AUTOMATIC);
 
@@ -161,11 +161,6 @@ void setup()
     } else {
         tent.state.init();
     }
-}
-
-void minutelyTick()
-{
-    tent.minutelyTick();
 }
 
 void loop(void)

--- a/src/Tomatotent.ino
+++ b/src/Tomatotent.ino
@@ -177,9 +177,9 @@ void loop(void)
     }
 
     if (tent.getCheckStats()) {
-        tent.check_temperature();
-        tent.check_humidity();
-        // tent.check_waterlevel(); // removed for stand alone controller
+        tent.checkTemperature();
+        tent.checkHumidity();
+        // tent.checkWaterLevel(); // removed for stand alone controller
         tent.adjustFan();
         tent.resetCheckStats();
     }

--- a/src/screen_manager.cpp
+++ b/src/screen_manager.cpp
@@ -10,8 +10,6 @@
 #include "screens/wifi.h"
 
 extern Tent tent;
-extern float fanSpeed;
-extern float fanSpeedPercent;
 
 void ScreenManager::setup()
 {

--- a/src/screens/home.cpp
+++ b/src/screens/home.cpp
@@ -74,11 +74,15 @@ void HomeScreen::drawTemperature()
     tft.fillRect(50, 60, 141, 25, ILI9341_BLACK);
     tft.setCursor(50, 60);
     tft.setTextColor(ILI9341_GREEN);
+
     tft.setTextSize(3);
+    if (tempUnit == 'F') {
+        tft.print(String::format("%.1f", tent.sensors.tentTemperatureF));
+    } else {
+        tft.print(String::format("%.1f", tent.sensors.tentTemperatureC));
+    }
 
-    tft.print(String::format("%.1f", temp));
     tft.setTextSize(2);
-
     if (tempUnit == 'F') {
         tft.print(" F");
     } else {
@@ -93,7 +97,7 @@ void HomeScreen::drawHumidity()
     tft.setTextColor(ILI9341_PINK);
     tft.setTextSize(3);
 
-    tft.print(String::format("%.1f", hum));
+    tft.print(String::format("%.1f", tent.sensors.tentHumidity));
 
     tft.setTextSize(2);
     tft.print(" %");
@@ -104,8 +108,7 @@ void HomeScreen::drawWaterLevel()
     const float waterLevelBoxHeight = 150;
     const int waterLevelBoxTop = 60;
 
-    int waterLevelHeight = floor((waterLevelBoxHeight / 100) * waterLevel);
-
+    int waterLevelHeight = floor((waterLevelBoxHeight / 100) * tent.sensors.waterLevel);
     int waterLevelTop = (waterLevelBoxHeight - waterLevelHeight) + waterLevelBoxTop - 1;
 
     //icon

--- a/src/screens/temp_unit.cpp
+++ b/src/screens/temp_unit.cpp
@@ -43,12 +43,12 @@ void TempUnitScreen::handleButton(Button& btn)
         tent.state.setTempUnit('F');
         renderButtons(true);
         screenManager.homeScreen();
-        tent.check_temperature();
+        tent.checkTemperature();
 
     } else if (btn.getName() == "tempCelsiusBtn") {
         tent.state.setTempUnit('C');
         renderButtons(true);
         screenManager.homeScreen();
-        tent.check_temperature();
+        tent.checkTemperature();
     }
 }

--- a/src/tent.cpp
+++ b/src/tent.cpp
@@ -10,6 +10,10 @@ Tent::Tent()
 
 void Tent::begin()
 {
+    Particle.variable("tentTemperatureC", sensors.tentTemperatureC);
+    Particle.variable("tentTemperatureF", sensors.tentTemperatureF);
+    Particle.variable("tentHumidity", sensors.tentHumidity);
+
     tp = new Timer(50000, &Tent::displayLightLow, *this, 1);
     tp1 = new Timer(60000, &Tent::displayLightOff, *this, 1);
 
@@ -19,14 +23,10 @@ void Tent::begin()
 void Tent::checkTemperature()
 {
     double currentTemp = sht20.readTemperature();
-    char tempUnit = state.getTempUnit();
 
-    if (tempUnit == 'F') {
-        currentTemp = (currentTemp * 1.8) + 32;
-    }
-
-    if ((temp == 0) || (temp != currentTemp)) {
-        temp = currentTemp;
+    if ((sensors.tentTemperatureC == 0) || (sensors.tentTemperatureC != currentTemp)) {
+        sensors.tentTemperatureC = currentTemp;
+        sensors.tentTemperatureF = (currentTemp * 1.8) + 32;
         screenManager.markNeedsRedraw(TEMPERATURE);
     }
 }
@@ -35,8 +35,8 @@ void Tent::checkHumidity()
 {
     double currentHumidity = sht20.readHumidity();
 
-    if ((hum == 0) || (hum != currentHumidity)) {
-        hum = currentHumidity;
+    if ((sensors.tentHumidity == 0) || (sensors.tentHumidity != currentHumidity)) {
+        sensors.tentHumidity = currentHumidity;
         screenManager.markNeedsRedraw(HUMIDITY);
     }
 }
@@ -45,8 +45,8 @@ void Tent::checkWaterLevel()
 {
     double currentWaterLevel = sht20.readHumidity();
 
-    if ((waterLevel == 0) || (waterLevel != currentWaterLevel)) {
-        waterLevel = currentWaterLevel;
+    if ((sensors.waterLevel == 0) || (sensors.waterLevel != currentWaterLevel)) {
+        sensors.waterLevel = currentWaterLevel;
         screenManager.markNeedsRedraw(WATER_LEVEL);
     }
 }
@@ -200,33 +200,29 @@ void Tent::adjustFan()
 
         float fanSpeedPercent = FAN_SPEED_MIN;
         float step = 5;
-        float tempFahrenheit = temp;
-        if (state.getTempUnit() == 'C') {
-            tempFahrenheit = (temp * 1.8) + 32;
-        }
 
-        if (tempFahrenheit > 70 || hum > 40) {
+        if (sensors.tentTemperatureF > 70 || sensors.tentHumidity > 40) {
             fanSpeedPercent += step;
         }
 
-        if (tempFahrenheit > 72 || hum > 50) {
+        if (sensors.tentTemperatureF > 72 || sensors.tentHumidity > 50) {
             fanSpeedPercent += step;
         }
 
-        if (tempFahrenheit > 74 || hum > 60) {
+        if (sensors.tentTemperatureF > 74 || sensors.tentHumidity > 60) {
             fanSpeedPercent += step;
         }
-        if (tempFahrenheit > 76 || hum > 70) {
+        if (sensors.tentTemperatureF > 76 || sensors.tentHumidity > 70) {
             fanSpeedPercent += step;
         }
-        if (tempFahrenheit > 78 || hum > 80) {
+        if (sensors.tentTemperatureF > 78 || sensors.tentHumidity > 80) {
             fanSpeedPercent += step;
         }
-        if (tempFahrenheit > 80 || hum > 90) {
+        if (sensors.tentTemperatureF > 80 || sensors.tentHumidity > 90) {
             fanSpeedPercent += step;
         }
         //for sensor fail
-        if (tempFahrenheit > 200 || hum > 200) {
+        if (sensors.tentTemperatureF > 200 || sensors.tentHumidity > 200) {
             fanSpeedPercent = FAN_SPEED_MIN + 15;
         }
 

--- a/src/tent.cpp
+++ b/src/tent.cpp
@@ -16,7 +16,7 @@ void Tent::begin()
     this->displayLightHigh();
 }
 
-void Tent::check_temperature()
+void Tent::checkTemperature()
 {
     double currentTemp = sht20.readTemperature();
     char tempUnit = state.getTempUnit();
@@ -31,7 +31,7 @@ void Tent::check_temperature()
     }
 }
 
-void Tent::check_humidity()
+void Tent::checkHumidity()
 {
     double currentHumidity = sht20.readHumidity();
 
@@ -41,7 +41,7 @@ void Tent::check_humidity()
     }
 }
 
-void Tent::check_waterlevel()
+void Tent::checkWaterLevel()
 {
     double currentWaterLevel = sht20.readHumidity();
 

--- a/src/tent.h
+++ b/src/tent.h
@@ -14,9 +14,6 @@
 #define DIM_PIN DAC
 
 extern DFRobot_SHT20 sht20;
-extern double temp;
-extern double hum;
-extern double waterLevel;
 
 class Tent {
 private:
@@ -31,6 +28,13 @@ public:
     Timer* tp;
     Timer* tp1;
     bool checkStats;
+
+    struct {
+        double tentTemperatureC;
+        double tentTemperatureF;
+        double tentHumidity;
+        double waterLevel;
+    } sensors;
 
     void begin();
     void adjustFan();

--- a/src/tent.h
+++ b/src/tent.h
@@ -35,9 +35,9 @@ public:
     void begin();
     void adjustFan();
     void countMinute();
-    void check_temperature();
-    void check_humidity();
-    void check_waterlevel();
+    void checkTemperature();
+    void checkHumidity();
+    void checkWaterLevel();
     void fan(String fanStatus);
     void doCheckStats();
     bool getCheckStats();


### PR DESCRIPTION
Sensor values are now stored inside a `tent.sensors` struct. This will make it easier to add SHT30 and other sensors in one place in the future.