### PR TITLE
Stop fan UI flashing every 7s

### DIFF
--- a/src/screens/fan.cpp
+++ b/src/screens/fan.cpp
@@ -73,12 +73,14 @@ void FanScreen::handleButton(Button& btn)
         renderButton(buttons[0]);
         renderButton(buttons[1]);
         tent.adjustFan();
+        screenManager.markNeedsRedraw(FAN);
 
     } else if (btn.getName() == "fanManualBtn") {
         tent.state.setFanAutoMode(false);
         renderButton(buttons[0]);
         renderButton(buttons[1]);
         tent.adjustFan();
+        screenManager.markNeedsRedraw(FAN);
 
     } else if (btn.getName() == "fanUpBtn") {
         float fanSpeedPercent = tent.state.getFanSpeed();
@@ -90,6 +92,7 @@ void FanScreen::handleButton(Button& btn)
             fanSpeedPercent += 5;
             tent.state.setFanSpeed(fanSpeedPercent);
             tent.adjustFan();
+            screenManager.markNeedsRedraw(FAN);
         }
 
     } else if (btn.getName() == "fanDownBtn") {
@@ -102,6 +105,7 @@ void FanScreen::handleButton(Button& btn)
             fanSpeedPercent -= 5;
             tent.state.setFanSpeed(fanSpeedPercent);
             tent.adjustFan();
+            screenManager.markNeedsRedraw(FAN);
         }
 
     } else if (btn.getName() == "fanOkBtn") {

--- a/src/tent.cpp
+++ b/src/tent.cpp
@@ -291,10 +291,13 @@ void Tent::adjustFan()
             fanSpeedPercent = FAN_SPEED_MIN + 15;
         }
 
-        state.setFanSpeed(fanSpeedPercent);
-        int fanSpeed = map(fanSpeedPercent, 0.0, 100.0, 0.0, 255.0);
-        analogWrite(FAN_SPEED_PIN, 255 - fanSpeed, 25000);
+        if (fanSpeedPercent != state.getFanSpeed()) {
+            state.setFanSpeed(fanSpeedPercent);
+            int fanSpeed = map(fanSpeedPercent, 0.0, 100.0, 0.0, 255.0);
+            analogWrite(FAN_SPEED_PIN, 255 - fanSpeed, 25000);
+
+            screenManager.markNeedsRedraw(FAN);
+        }
     }
 
-    screenManager.markNeedsRedraw(FAN);
 }


### PR DESCRIPTION
Redraw is now only requested when something changes, i.e. auto mode causes fan speed to increase/decrease or manual up/down is touched.