### PR TITLE
Metrics + API server

### DIFF
--- a/project.properties
+++ b/project.properties
@@ -2,3 +2,4 @@ name=Tomatotent
 dependencies.Adafruit_ILI9341=1.0.3
 dependencies.XPT2046_Touch=1.1.7
 dependencies.Adafruit_mfGFX=1.0.4
+dependencies.WebServer=0.0.2

--- a/project.properties
+++ b/project.properties
@@ -3,3 +3,4 @@ dependencies.Adafruit_ILI9341=1.0.3
 dependencies.XPT2046_Touch=1.1.7
 dependencies.Adafruit_mfGFX=1.0.4
 dependencies.WebServer=0.0.2
+dependencies.ArduinoJson=6.14.1

--- a/src/Tomatotent.ino
+++ b/src/Tomatotent.ino
@@ -4,12 +4,14 @@
 #include "tent.h"
 #include "screen_manager.h"
 #include "assets.h"
+#include "api_server.h"
 
 PRODUCT_ID(10167);
 PRODUCT_VERSION(13);
 
 Tent tent;
 ScreenManager screenManager;
+ApiServer server;
 
 SYSTEM_MODE(SEMI_AUTOMATIC);
 
@@ -103,6 +105,8 @@ void setup()
     screenManager.setup();
     screenManager.homeScreen();
     tent.setup();
+
+    server.begin();
 }
 
 void loop(void)
@@ -115,4 +119,6 @@ void loop(void)
     if (screenManager.current) {
         screenManager.current->update();
     }
+
+    server.processConnection();
 }

--- a/src/api_server.cpp
+++ b/src/api_server.cpp
@@ -21,6 +21,17 @@ void defaultCmd(WebServer& server, WebServer::ConnectionType type, char* url_tai
     server << "welcome to tomatotent";
 }
 
+void apiCmd(WebServer& server, WebServer::ConnectionType type, char* url_tail, bool tail_complete)
+{
+    switch (type) {
+    case WebServer::GET: {
+        server.httpSuccess();
+        server << "api help";
+        break;
+    }
+    }
+}
+
 void metricsCmd(WebServer& server, WebServer::ConnectionType type, char* url_tail, bool tail_complete)
 {
     server.httpSuccess("text/plain; version=0.0.4; charset=utf-8");
@@ -63,5 +74,6 @@ void ApiServer::begin()
     WebServer::begin();
 
     setDefaultCommand(&defaultCmd);
+    addCommand("api", &apiCmd);
     addCommand("metrics", &metricsCmd);
 }

--- a/src/api_server.cpp
+++ b/src/api_server.cpp
@@ -2,6 +2,9 @@
 #define WEBDUINO_FAVICON_DATA ""
 #include <WebServer.h>
 #include "api_server.h"
+#include "tent.h"
+
+extern Tent tent;
 
 // no-cost stream operator as described at
 // http://sundial.org/arduino/?page_id=119
@@ -18,9 +21,47 @@ void defaultCmd(WebServer& server, WebServer::ConnectionType type, char* url_tai
     server << "welcome to tomatotent";
 }
 
+void metricsCmd(WebServer& server, WebServer::ConnectionType type, char* url_tail, bool tail_complete)
+{
+    server.httpSuccess("text/plain; version=0.0.4; charset=utf-8");
+
+    server << "# HELP tent_temperature The temperature of the tent in Celsius\n";
+    server << "# TYPE tent_temperature gauge\n";
+    server << "tent_temperature " << tent.sensors.tentTemperatureC << "\n";
+
+    server << "# HELP tent_humidity The relative humidity of the tent\n";
+    server << "# TYPE tent_humidity gauge\n";
+    server << "tent_humidity " << tent.sensors.tentHumidity << "\n";
+
+    server << "# HELP soil_temperature The temperature of the soil in Celsius\n";
+    server << "# TYPE soil_temperature gauge\n";
+    server << "soil_temperature " << tent.sensors.soilTemperatureC << "\n";
+
+    server << "# HELP soil_moisture The moisture of the soil in Celsius\n";
+    server << "# TYPE soil_moisture gauge\n";
+    server << "soil_moisture " << tent.sensors.soilMoisture << "\n";
+
+    server << "# HELP is_day Is it daylight in the tent?\n";
+    server << "# TYPE is_day gauge\n";
+    server << "is_day " << (tent.state.isDay() ? 1 : 0) << "\n";
+
+    server << "# HELP day_count How many days into the grow?\n";
+    server << "# TYPE day_count gauge\n";
+    server << "day_count " << tent.state.getDayCount() << "\n";
+
+    server << "# HELP day_duration How many minutes in a day?\n";
+    server << "# TYPE day_duration gauge\n";
+    server << "day_duration " << tent.state.getDayDuration() << "\n";
+
+    server << "# HELP minutes_in_photoperiod How many minutes into the current photoperiod?\n";
+    server << "# TYPE minutes_in_photoperiod gauge\n";
+    server << "minutes_in_photoperiod " << tent.state.getMinutesInPhotoperiod() << "\n";
+}
+
 void ApiServer::begin()
 {
     WebServer::begin();
 
     setDefaultCommand(&defaultCmd);
+    addCommand("metrics", &metricsCmd);
 }

--- a/src/api_server.cpp
+++ b/src/api_server.cpp
@@ -83,7 +83,7 @@ void metricsCmd(WebServer& server, WebServer::ConnectionType type, char* url_tai
 
         server << "# HELP tomatotent_fan_speed Speed of the fan\n";
         server << "# TYPE tomatotent_fan_speed gauge\n";
-        server << "tomatotent_fan_auto " << (tent.state.getFanSpeed() + 5) << "\n";
+        server << "tomatotent_fan_speed " << (tent.state.getFanSpeed() + 5) << "\n";
     }
 }
 

--- a/src/api_server.cpp
+++ b/src/api_server.cpp
@@ -57,7 +57,7 @@ void metricsCmd(WebServer& server, WebServer::ConnectionType type, char* url_tai
     if (tent.rawSensors.soilMoisture != -1) {
         server << "# HELP tomatotent_soil_moisture The moisture level in the soil\n";
         server << "# TYPE tomatotent_soil_moisture gauge\n";
-        server << "tomatotent_soil_moisture " << tent.rawSensors.soilMoisture << "\n";
+        server << "tomatotent_soil_moisture " << tent.sensors.waterLevel << "\n";
     }
 
     if (tent.state.getDayCount() != -1) {
@@ -67,7 +67,7 @@ void metricsCmd(WebServer& server, WebServer::ConnectionType type, char* url_tai
 
         server << "# HELP tomatotent_light_on Is it daylight in the tent?\n";
         server << "# TYPE tomatotent_light_on gauge\n";
-        server << "tomatotent_light_on " << (tent.state.isDay() ? 1 : 0) << "\n"; // TODO expose sunrise/sunset
+        server << "tomatotent_light_on " << tent.rawSensors.lightBrightness << "\n";
 
         server << "# HELP tomatotent_light_period How many minutes of daylight in the tent?\n";
         server << "# TYPE tomatotent_light_period gauge\n";

--- a/src/api_server.cpp
+++ b/src/api_server.cpp
@@ -37,45 +37,53 @@ void metricsCmd(WebServer& server, WebServer::ConnectionType type, char* url_tai
     server.httpSuccess("text/plain; version=0.0.4; charset=utf-8");
 
     if (tent.rawSensors.tentTemperature != -1) {
-        server << "# HELP tent_temperature The temperature of the tent in Celsius\n";
-        server << "# TYPE tent_temperature gauge\n";
-        server << "tent_temperature " << tent.rawSensors.tentTemperature << "\n";
+        server << "# HELP tomatotent_air_temperature The temperature of the air in Celsius\n";
+        server << "# TYPE tomatotent_air_temperature gauge\n";
+        server << "tomatotent_air_temperature " << tent.rawSensors.tentTemperature << "\n";
     }
 
     if (tent.rawSensors.tentHumidity != -1) {
-        server << "# HELP tent_humidity The relative humidity of the tent\n";
-        server << "# TYPE tent_humidity gauge\n";
-        server << "tent_humidity " << tent.rawSensors.tentHumidity << "\n";
+        server << "# HELP tomatotent_air_humidity The relative humidity of the air\n";
+        server << "# TYPE tomatotent_air_humidity gauge\n";
+        server << "tomatotent_air_humidity " << tent.rawSensors.tentHumidity << "\n";
     }
 
     if (tent.rawSensors.soilTemperature != -1) {
-        server << "# HELP soil_temperature The temperature of the soil in Celsius\n";
-        server << "# TYPE soil_temperature gauge\n";
-        server << "soil_temperature " << tent.rawSensors.soilTemperature << "\n";
+        server << "# HELP tomatotent_soil_temperature The temperature of the soil in Celsius\n";
+        server << "# TYPE tomatotent_soil_temperature gauge\n";
+        server << "tomatotent_soil_temperature " << tent.rawSensors.soilTemperature << "\n";
     }
 
     if (tent.rawSensors.soilMoisture != -1) {
-        server << "# HELP soil_moisture The moisture of the soil in Celsius\n";
-        server << "# TYPE soil_moisture gauge\n";
-        server << "soil_moisture " << tent.rawSensors.soilMoisture << "\n";
+        server << "# HELP tomatotent_soil_moisture The moisture level in the soil\n";
+        server << "# TYPE tomatotent_soil_moisture gauge\n";
+        server << "tomatotent_soil_moisture " << tent.rawSensors.soilMoisture << "\n";
     }
 
     if (tent.state.getDayCount() != -1) {
-        server << "# HELP is_day Is it daylight in the tent?\n";
-        server << "# TYPE is_day gauge\n";
-        server << "is_day " << (tent.state.isDay() ? 1 : 0) << "\n";
+        server << "# HELP tomatotent_grow_days How many days since the grow started?\n";
+        server << "# TYPE tomatotent_grow_days gauge\n";
+        server << "tomatotent_grow_days " << tent.state.getDayCount() << "\n";
 
-        server << "# HELP day_count How many days into the grow?\n";
-        server << "# TYPE day_count gauge\n";
-        server << "day_count " << tent.state.getDayCount() << "\n";
+        server << "# HELP tomatotent_light_on Is it daylight in the tent?\n";
+        server << "# TYPE tomatotent_light_on gauge\n";
+        server << "tomatotent_light_on " << (tent.state.isDay() ? 1 : 0) << "\n"; // TODO expose sunrise/sunset
 
-        server << "# HELP day_duration How many minutes in a day?\n";
-        server << "# TYPE day_duration gauge\n";
-        server << "day_duration " << tent.state.getDayDuration() << "\n";
+        server << "# HELP tomatotent_light_period How many minutes of daylight in the tent?\n";
+        server << "# TYPE tomatotent_light_period gauge\n";
+        server << "tomatotent_light_period " << tent.state.getDayDuration() << "\n";
 
-        server << "# HELP minutes_in_photoperiod How many minutes into the current photoperiod?\n";
-        server << "# TYPE minutes_in_photoperiod gauge\n";
-        server << "minutes_in_photoperiod " << tent.state.getMinutesInPhotoperiod() << "\n";
+        server << "# HELP tomatotent_period_progress How many minutes into the current photoperiod?\n";
+        server << "# TYPE tomatotent_period_progress gauge\n";
+        server << "tomatotent_period_progress " << tent.state.getMinutesInPhotoperiod() << "\n";
+
+        server << "# HELP tomatotent_fan_auto Is the fan running in automatic mode?\n";
+        server << "# TYPE tomatotent_fan_auto gauge\n";
+        server << "tomatotent_fan_auto " << (tent.state.getFanAutoMode() ? 1 : 0) << "\n";
+
+        server << "# HELP tomatotent_fan_speed Speed of the fan\n";
+        server << "# TYPE tomatotent_fan_speed gauge\n";
+        server << "tomatotent_fan_auto " << (tent.state.getFanSpeed() + 5) << "\n";
     }
 }
 

--- a/src/api_server.cpp
+++ b/src/api_server.cpp
@@ -36,37 +36,47 @@ void metricsCmd(WebServer& server, WebServer::ConnectionType type, char* url_tai
 {
     server.httpSuccess("text/plain; version=0.0.4; charset=utf-8");
 
-    server << "# HELP tent_temperature The temperature of the tent in Celsius\n";
-    server << "# TYPE tent_temperature gauge\n";
-    server << "tent_temperature " << tent.sensors.tentTemperatureC << "\n";
+    if (tent.rawSensors.tentTemperature != -1) {
+        server << "# HELP tent_temperature The temperature of the tent in Celsius\n";
+        server << "# TYPE tent_temperature gauge\n";
+        server << "tent_temperature " << tent.rawSensors.tentTemperature << "\n";
+    }
 
-    server << "# HELP tent_humidity The relative humidity of the tent\n";
-    server << "# TYPE tent_humidity gauge\n";
-    server << "tent_humidity " << tent.sensors.tentHumidity << "\n";
+    if (tent.rawSensors.tentHumidity != -1) {
+        server << "# HELP tent_humidity The relative humidity of the tent\n";
+        server << "# TYPE tent_humidity gauge\n";
+        server << "tent_humidity " << tent.rawSensors.tentHumidity << "\n";
+    }
 
-    server << "# HELP soil_temperature The temperature of the soil in Celsius\n";
-    server << "# TYPE soil_temperature gauge\n";
-    server << "soil_temperature " << tent.sensors.soilTemperatureC << "\n";
+    if (tent.rawSensors.soilTemperature != -1) {
+        server << "# HELP soil_temperature The temperature of the soil in Celsius\n";
+        server << "# TYPE soil_temperature gauge\n";
+        server << "soil_temperature " << tent.rawSensors.soilTemperature << "\n";
+    }
 
-    server << "# HELP soil_moisture The moisture of the soil in Celsius\n";
-    server << "# TYPE soil_moisture gauge\n";
-    server << "soil_moisture " << tent.sensors.soilMoisture << "\n";
+    if (tent.rawSensors.soilMoisture != -1) {
+        server << "# HELP soil_moisture The moisture of the soil in Celsius\n";
+        server << "# TYPE soil_moisture gauge\n";
+        server << "soil_moisture " << tent.rawSensors.soilMoisture << "\n";
+    }
 
-    server << "# HELP is_day Is it daylight in the tent?\n";
-    server << "# TYPE is_day gauge\n";
-    server << "is_day " << (tent.state.isDay() ? 1 : 0) << "\n";
+    if (tent.state.getDayCount() != -1) {
+        server << "# HELP is_day Is it daylight in the tent?\n";
+        server << "# TYPE is_day gauge\n";
+        server << "is_day " << (tent.state.isDay() ? 1 : 0) << "\n";
 
-    server << "# HELP day_count How many days into the grow?\n";
-    server << "# TYPE day_count gauge\n";
-    server << "day_count " << tent.state.getDayCount() << "\n";
+        server << "# HELP day_count How many days into the grow?\n";
+        server << "# TYPE day_count gauge\n";
+        server << "day_count " << tent.state.getDayCount() << "\n";
 
-    server << "# HELP day_duration How many minutes in a day?\n";
-    server << "# TYPE day_duration gauge\n";
-    server << "day_duration " << tent.state.getDayDuration() << "\n";
+        server << "# HELP day_duration How many minutes in a day?\n";
+        server << "# TYPE day_duration gauge\n";
+        server << "day_duration " << tent.state.getDayDuration() << "\n";
 
-    server << "# HELP minutes_in_photoperiod How many minutes into the current photoperiod?\n";
-    server << "# TYPE minutes_in_photoperiod gauge\n";
-    server << "minutes_in_photoperiod " << tent.state.getMinutesInPhotoperiod() << "\n";
+        server << "# HELP minutes_in_photoperiod How many minutes into the current photoperiod?\n";
+        server << "# TYPE minutes_in_photoperiod gauge\n";
+        server << "minutes_in_photoperiod " << tent.state.getMinutesInPhotoperiod() << "\n";
+    }
 }
 
 void ApiServer::begin()

--- a/src/api_server.cpp
+++ b/src/api_server.cpp
@@ -58,6 +58,10 @@ void metricsCmd(WebServer& server, WebServer::ConnectionType type, char* url_tai
         server << "# HELP tomatotent_soil_moisture The moisture level in the soil\n";
         server << "# TYPE tomatotent_soil_moisture gauge\n";
         server << "tomatotent_soil_moisture " << tent.sensors.waterLevel << "\n";
+
+        server << "# HELP tomatotent_soil_capacitance The capacitance level of the moisture sensor in the soil\n";
+        server << "# TYPE tomatotent_soil_capacitance gauge\n";
+        server << "tomatotent_soil_capacitance " << tent.rawSensors.soilMoisture << "\n";
     }
 
     if (tent.state.getDayCount() != -1) {

--- a/src/api_server.cpp
+++ b/src/api_server.cpp
@@ -5,11 +5,14 @@
 
 // no-cost stream operator as described at
 // http://sundial.org/arduino/?page_id=119
-template<class T>
-inline Print &operator <<(Print &obj, T arg)
-{ obj.print(arg); return obj; }
+template <class T>
+inline Print& operator<<(Print& obj, T arg)
+{
+    obj.print(arg);
+    return obj;
+}
 
-void defaultCmd(WebServer &server, WebServer::ConnectionType type, char *url_tail, bool tail_complete)
+void defaultCmd(WebServer& server, WebServer::ConnectionType type, char* url_tail, bool tail_complete)
 {
     server.httpSuccess();
     server << "welcome to tomatotent";

--- a/src/api_server.cpp
+++ b/src/api_server.cpp
@@ -1,0 +1,23 @@
+#include "Particle.h"
+#define WEBDUINO_FAVICON_DATA ""
+#include <WebServer.h>
+#include "api_server.h"
+
+// no-cost stream operator as described at
+// http://sundial.org/arduino/?page_id=119
+template<class T>
+inline Print &operator <<(Print &obj, T arg)
+{ obj.print(arg); return obj; }
+
+void defaultCmd(WebServer &server, WebServer::ConnectionType type, char *url_tail, bool tail_complete)
+{
+    server.httpSuccess();
+    server << "welcome to tomatotent";
+}
+
+void ApiServer::begin()
+{
+    WebServer::begin();
+
+    setDefaultCommand(&defaultCmd);
+}

--- a/src/api_server.h
+++ b/src/api_server.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "Particle.h"
+#define WEBDUINO_NO_IMPLEMENTATION
+#include <WebServer.h>
+
+class ApiServer : public WebServer {
+public:
+    ApiServer()
+        : WebServer("", 80) {};
+
+    void begin();
+};

--- a/src/tent.cpp
+++ b/src/tent.cpp
@@ -122,7 +122,7 @@ void Tent::checkSoil()
         return;
     }
 
-    int waterLevel = (int)((moisture - 244) * 100 / (425.0 - 244.0));
+    int waterLevel = (int)((moisture - 244) * 100 / (465.0 - 244.0));
     if (waterLevel > 99) {
         waterLevel = 99;
     } else if (waterLevel < 0) {

--- a/src/tent.cpp
+++ b/src/tent.cpp
@@ -199,20 +199,24 @@ int Tent::growLight(String brightness)
         analogWrite(GROW_LIGHT_BRIGHTNESS_PIN, maxBrightness, 25000);
         digitalWrite(GROW_LIGHT_ON_OFF_PIN, HIGH);
         growLightStatus = brightness;
+        rawSensors.lightBrightness = 1.0;
 
     } else if (brightness == "LOW") {
         analogWrite(GROW_LIGHT_BRIGHTNESS_PIN, minBrightness, 25000);
         digitalWrite(GROW_LIGHT_ON_OFF_PIN, HIGH);
         growLightStatus = brightness;
         dimTimeout = 15;
+        rawSensors.lightBrightness = 0.1;
 
     } else if (brightness == "MUTE") {
         digitalWrite(GROW_LIGHT_ON_OFF_PIN, LOW);
         growLightStatus = brightness;
+        rawSensors.lightBrightness = 0.0;
 
     } else if (brightness == "OFF") {
         digitalWrite(GROW_LIGHT_ON_OFF_PIN, LOW);
         growLightStatus = brightness;
+        rawSensors.lightBrightness = 0.0;
     }
 
     return 1;
@@ -247,6 +251,7 @@ void Tent::fadeGrowLight(String mode, int percent)
     }
     analogWrite(GROW_LIGHT_BRIGHTNESS_PIN, brightness, 25000);
     digitalWrite(GROW_LIGHT_ON_OFF_PIN, HIGH);
+    rawSensors.lightBrightness = percent / 100.0;
 }
 
 void Tent::dimGrowLight()

--- a/src/tent.cpp
+++ b/src/tent.cpp
@@ -251,7 +251,7 @@ void Tent::fadeGrowLight(String mode, int percent)
     }
     analogWrite(GROW_LIGHT_BRIGHTNESS_PIN, brightness, 25000);
     digitalWrite(GROW_LIGHT_ON_OFF_PIN, HIGH);
-    rawSensors.lightBrightness = percent / 100.0;
+    rawSensors.lightBrightness = brightness / 255.0;
 }
 
 void Tent::dimGrowLight()

--- a/src/tent.cpp
+++ b/src/tent.cpp
@@ -21,6 +21,7 @@ void Tent::setup()
     Particle.variable("tentHumidity", sensors.tentHumidity);
     Particle.variable("soilTemperatureC", sensors.soilTemperatureC);
     Particle.variable("soilTemperatureF", sensors.soilTemperatureF);
+    Particle.variable("soilMoisture", rawSensors.soilMoisture);
     Particle.variable("waterLevel", sensors.waterLevel);
 
     // init sensors

--- a/src/tent.h
+++ b/src/tent.h
@@ -54,6 +54,7 @@ public:
     } sensors;
 
     struct {
+        double lightBrightness;
         double tentTemperature;
         double tentHumidity;
         double soilTemperature;

--- a/src/tent.h
+++ b/src/tent.h
@@ -39,6 +39,8 @@ private:
     void displayLightLow();
     void displayLightOff();
 
+    void publishMetrics();
+
 public:
     Tent();
     TentState state;

--- a/src/tent.h
+++ b/src/tent.h
@@ -50,9 +50,15 @@ public:
         double tentHumidity;
         double soilTemperatureC;
         double soilTemperatureF;
-        double soilMoisture;
         int waterLevel;
     } sensors;
+
+    struct {
+        double tentTemperature;
+        double tentHumidity;
+        double soilTemperature;
+        int soilMoisture;
+    } rawSensors;
 
     void setup();
     void start();

--- a/src/tent_state.cpp
+++ b/src/tent_state.cpp
@@ -7,6 +7,7 @@ TentState::TentState()
 
 void TentState::begin()
 {
+    Particle.variable("isDay", eeprom.isDay);
     Particle.variable("dayCounter", eeprom.dayCounter);
     Particle.variable("fanAutoMode", eeprom.fanAutoMode);
     Particle.variable("minutesInPhotoperiod", eeprom.minutesInPhotoperiod);


### PR DESCRIPTION
- adds web server running on port 80
- adds /metrics http endpoint in Prometheus/OpenMetrics format
- adds /api http endpoint for api help
- adds /api/fan http endpoint for fan status and control via json
- publishes metrics json payload to Particle once a minute
- ensures raw sensor values are stored and sent to metrics collectors without rounding
- tracks light brightness as a metric
- tweaks chirp soil sensor thresholds 